### PR TITLE
feat(tokens): add gradient background token for navbar button

### DIFF
--- a/src/components/sections/TestSection.tsx
+++ b/src/components/sections/TestSection.tsx
@@ -33,7 +33,7 @@ const TestSection = () => {
         </Select>
       </div>
       <div>
-            <button className=" bg-button-primary-primary-bg-default text-button-primary-primary-text hover:bg-button-primary-primary-bg-hover focus:bg-button-primary-primary-bg-focus hover:text-button-primary-primary-text-hover p-1 ml-2"> Esto es un botón de prueba </button>
+            <button className="bg-[image:var(--color-button-bg-gradient)] text-button-primary-primary-text hover:bg-button-primary-primary-bg-hover focus:bg-button-primary-primary-bg-focus hover:text-button-primary-primary-text-hover p-1 ml-2"> Esto es un botón de prueba </button>
           </div>
     </section>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -91,6 +91,8 @@
   --color-white: #ffffff;
   --color-black: #0e0e0e;
 
+  --color-gradient-brand: linear-gradient(90deg, #f76702 0%, #f83c85 50%, #7858ff 100%);
+
   /* Semantic Tokens */
 
   --color-background-light: #fefefe;
@@ -157,6 +159,8 @@
   --color-button-disabled-bg: #d1d1d1;
   --color-button-disabled-text: #6b6b6b;
   --color-button-disabled-border: #d1d1d1;
+
+  --color-button-bg-gradient: var(--color-gradient-brand); /* To use it for example in the navbar button (which is the case for now) this is the way to apply it in the className "bg-[image:var(--color-button-bg-gradient)]"
 
   /* Toggle */
   --color-toggle-bg-default: #f5f5f5;
@@ -269,3 +273,9 @@
   --carousel-arrow-default: #0e0e0e;
   --carousel-arrow-disabled: #e7e7e7;
 }
+
+.btn-gradient {
+  background-image: var(--button-primary-bg-gradient);
+}
+
+


### PR DESCRIPTION
### What’s new

- Added a new primitive token: `--color-gradient-brand`
- Added a new component token: `--color-button-bg-gradient`
- Applied the gradient background to the primary button using `bg-[image:var(--color-button-bg-gradient)]`

### Why

To introduce support for gradient backgrounds in components, especially buttons, using our semantic token system and maintaining consistency with the Athena design system.

### Notes

No Tailwind plugin or custom utility was needed. This leverages the new CSS-first approach using `@theme` and the `bg-[image:var(--...)]` syntax.
