### PR TITLE
Fix/naming tokens

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,20 @@
 import "@/styles/globals.css";
 import type { Metadata } from "next";
-
 import Footer from "@/components/layout/Footer/Footer";
 import { AppProviders } from "@/lib/providers";
+import { Ubuntu, Nunito } from "next/font/google";
+
+const ubuntu = Ubuntu({
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  variable: "--font-primary",
+});
+
+const nunito = Nunito({
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  variable: "--font-secondary",
+});
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://shehub.es"),
@@ -30,7 +42,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className={`${ubuntu.variable} ${nunito.variable}`} suppressHydrationWarning>
       <body>
         <AppProviders>
           {children}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -176,7 +176,7 @@
 
   --color-toggle-border-default: #d1d1d1;
   --color-toggle-border-active: #7858ff;
-  --color-toggle-border-focus: #7858ff;
+  --color-toggle-border-focus: #b9b1ff;
 
   /* Navigation menu */
   --color-navigationmenu-label: #0e0e0e;
@@ -275,8 +275,9 @@
   --carousel-arrow-default: #0e0e0e;
   --carousel-arrow-disabled: #e7e7e7;
 
-  --font-sans: 'Ubuntu', sans-serif;
-  --font-alt: 'Nunito', sans-serif; 
+  /*Font Family*/
+  --font-primary: 'Ubuntu', sans-serif;
+  --font-secondary: 'Nunito', sans-serif; 
 
     /*Font Size*/
   --text-size-1000: 60px;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,4 @@
 @import "tailwindcss";
-@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@400;500;700&family=Nunito:wght@400;500;700&display=swap');
-
 
 @theme {
   /* Primitive Tokens*/
@@ -313,4 +311,10 @@
   --font-weight-medium: 500;
   --font-weight-heavy: 700;
 
+}
+
+@layer base {
+  body {
+    @apply font-primary;
+  }
 }


### PR DESCRIPTION
- Replaced Google Fonts @import with next/font for optimized Next.js font loading.
- Mapped Ubuntu to --font-primary and set it as the global default (font-primary).
- Mapped Nunito to --font-secondary and exposed it as the font-secondary utility.
- Updated globals.css to apply font-primary to <body> via @layer base.
- Removed unnecessary Google Fonts CSS import to prevent FOUT and improve performance.

Impact:
- Global font-family now correctly applies Ubuntu as the primary font.
- font-secondary utility is available to selectively apply Nunito.
- Improved loading performance and reduced layout shift.