### PR TITLE
feat(icons): add icon components with Lucide support

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Navbar from "@/components/layout/navbar/Navbar";
+import Navbar from "@/components/layout/NavBar/Navbar";
 import CollaboratorsSection from "@/sections/CollaboratorsSection/CollaboratorsSection";
 import CTASection from "@/sections/CTASection/CTASection";
 import FAQsSection from "@/sections/FAQsSection/FAQsSection";

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { LucideProps } from "lucide-react";
+import clsx from "clsx";
+
+type IconSize = "sm" | "md" | "lg" | "xl" | "2xl" | number;
+
+interface IconProps {
+    icon: React.FC<LucideProps>;
+    size?: IconSize;
+    interactive?: boolean;
+    className?: string;
+    onClick?: () => void;
+    "aria-label"?: string;
+}
+
+const sizeMap: Record<Exclude<IconSize, number>, number> = {
+    sm: 16,
+    md: 20,
+    lg: 24,
+    xl: 32,
+    "2xl": 44,
+};
+
+export const Icon: React.FC<IconProps> = ({
+    icon: IconComponent,
+    size = "md",
+    interactive = false,
+    className,
+    onClick,
+    ...props
+}) => {
+    const px = typeof size === "number" ? size : sizeMap[size];
+    const Wrapper = interactive ? "button" : "span";
+
+    return (
+        <Wrapper
+            onClick={onClick}
+            className={clsx(
+                "flex items-center justify-center rounded-full",
+                "text-[var(--color-icon-default)]",
+                interactive &&
+                "cursor-pointer hover:text-[var(--color-icon-hover)] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-icon-hover)]",
+                className
+            )}
+            style={{
+                width: px >= 44 ? px : 44,
+                height: px >= 44 ? px : 44,
+            }}
+            {...props}
+        >
+            <IconComponent size={px} strokeWidth={2} color="currentColor"/>
+        </Wrapper>
+    );
+};

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -37,7 +37,6 @@ export const Icon: React.FC<IconProps> = ({
             onClick={onClick}
             className={clsx(
                 "flex items-center justify-center rounded-full",
-                "text-[var(--color-icon-default)]",
                 interactive &&
                 "cursor-pointer hover:text-[var(--color-icon-hover)] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-icon-hover)]",
                 className

--- a/src/sections/HeroSection/HeroSection.tsx
+++ b/src/sections/HeroSection/HeroSection.tsx
@@ -1,9 +1,13 @@
 import SectionWrapper from '@/components/layout/section-wrapper/SectionWrapper';
+import { Icon } from '@/components/ui/icon';
+import { Globe, Linkedin } from 'lucide-react';
 
 const HeroSection = () => {
   return (
     <SectionWrapper id="hero" className="gap-20 grid min-h-[716px] text-black mt-10">
       <h2>Hero Section</h2>
+      <Icon icon={Globe} size="lg" aria-label='Language selector' />
+      <Icon icon={Linkedin} size="2xl" interactive onClick={() => alert ("Go to LinkedIn")}/>
     </SectionWrapper>
   )
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -250,7 +250,7 @@
 
   /* Icons */
   --color-icon-default: #292929;
-  --color-icon-hover: #e9e8ff;
+  --color-icon-hover: #6230F7;
 
   /* Accordion */
   --color-accordion-bg-default: #ffffff;


### PR DESCRIPTION
✅ Main features:
- Accepts any Lucide icon as a prop (icon: React.FC<LucideProps>)
- Supports 5 predefined sizes (sm, md, lg, xl, 2xl) and custom numeric values
- Handles interactive states (hover) with proper accessibility
- Enforces a minimum touch target of 44x44px to comply with WCAG 2.1

♿ Accessibility notes:
- Uses <button> when interactive is true, otherwise falls back to <span>
- Provides support for aria-label
- Ensures consistent color behavior across states via CSS-first approach