### PR TITLE
Feat/our impact section

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -16,7 +16,7 @@ const cardVariants = cva(
                     [
                         'w-[13.5rem] h-[7rem] inline-flex items-center justify-center gap-7 p-8 cursor-pointer !rounded-[8px]',
                     ].join(' '),
-                nonClickable: ['flex flex-col items-start gap-2.5 p-10 w-[18.5rem] h-[14.25rem]',
+                nonClickable: ['flex flex-col items-start gap-2.5 p-10 w-[18.5rem]',
                 ].join(' '),
                 nonClickableWithIcon: ['flex flex-col items-start gap-7 p-10 w-[24.25rem] h-[20rem]'
                 ].join(' '),

--- a/src/sections/ImpactSection/ImpactSection.tsx
+++ b/src/sections/ImpactSection/ImpactSection.tsx
@@ -1,3 +1,4 @@
+import styles from './impactSection.module.css';
 import SectionWrapper from '@/components/layout/section-wrapper/SectionWrapper'
 import { Card } from '@/components/ui/card'
 
@@ -27,23 +28,24 @@ const impactProps = [
 export const ImpactSection = () => {
   return (
     <SectionWrapper id="our-impact" className='flex flex-col py-24 gap-16 bg-primary'>
-      <div  className='flex flex-col justify-center items-center gap-4' >
-                <h2 className='text-white text-size-900 font-bold font-primary '>Our Impact So Far</h2>
-                <p className='font-secondary text-size-500 leading-line-height-body-1 text-white'>
-                SheHub is already helping women build confidence, portfolios and real experience.
-                </p>
+      <div className='flex flex-col justify-center items-center gap-4' >
+        <h2 className='text-white text-size-900 font-bold font-primary '>Our Impact So Far</h2>
+        <p className='font-secondary text-size-500 leading-line-height-body-1 text-white'>
+          SheHub is already helping women build confidence, portfolios and real experience.
+        </p>
       </div>
       <div className='grid grid-cols-1 md:grid-cols-4 gap-[1.94rem] justify-center'>
-      {impactProps.map((item, index) => (
-        <Card
-          key={index}
-          type='nonClickable'
-          title={item.title}
-          description={item.description}
-          color='white'
-          radius='lg'
-        />
-      ))}
+        {impactProps.map((item, index) => (
+          <Card
+            key={index}
+            type='nonClickable'
+            title={item.title}
+            description={item.description}
+            color='white'
+            radius='lg'
+            className={styles.impactCard}
+          />
+        ))}
       </div>
     </SectionWrapper>
   )

--- a/src/sections/ImpactSection/ImpactSection.tsx
+++ b/src/sections/ImpactSection/ImpactSection.tsx
@@ -1,9 +1,50 @@
 import SectionWrapper from '@/components/layout/section-wrapper/SectionWrapper'
+import { Card } from '@/components/ui/card'
+
+const impactProps = [
+  {
+    title: "100+",
+    description:
+      "women joined the community in our first month"
+  },
+  {
+    title: "3+",
+    description:
+      "active teams working across design, dev, product, and more"
+  },
+  {
+    title: "760+",
+    description:
+      "hours invested by contributors in real workflows"
+  },
+  {
+    title: "5+",
+    description:
+      "interviews landed by contributors in our first month"
+  }
+]
 
 export const ImpactSection = () => {
   return (
-    <SectionWrapper id="about" className='gap-14 grid min-h-[584px] text-black'>
-        <h2>Impact Section</h2>
+    <SectionWrapper id="our-impact" className='flex flex-col py-24 gap-16 bg-primary'>
+      <div  className='flex flex-col justify-center items-center gap-4' >
+                <h2 className='text-white text-size-900 font-bold font-primary '>Our Impact So Far</h2>
+                <p className='font-secondary text-size-500 leading-line-height-body-1 text-white'>
+                SheHub is already helping women build confidence, portfolios and real experience.
+                </p>
+      </div>
+      <div className='grid grid-cols-1 md:grid-cols-4 gap-[1.94rem] justify-center'>
+      {impactProps.map((item, index) => (
+        <Card
+          key={index}
+          type='nonClickable'
+          title={item.title}
+          description={item.description}
+          color='white'
+          radius='lg'
+        />
+      ))}
+      </div>
     </SectionWrapper>
   )
 }

--- a/src/sections/ImpactSection/impactSection.module.css
+++ b/src/sections/ImpactSection/impactSection.module.css
@@ -1,0 +1,9 @@
+.impactCard h3 {
+    font-size: var(--text-size-700) !important;
+    line-height: var(--spacing-line-height-heading-4)
+}
+
+.impactCard p {
+    color: var(--color-card-white-title) !important;
+    line-height: var(--spacing-line-height-body-3) !important;
+}


### PR DESCRIPTION
- Add ImpactSection.module.css with .impactCard rules
  - Title: 30/36 (var(--text-size-700) / var(--spacing-line-height-heading-4))
  - Description: black + body-3 line-height
- Apply module class to Impact cards (className={styles.impactCard})
- Remove h-[14.25rem] from Card nonClickable to size height to content
- No Card API changes; overrides scoped to Impact section only