### PR TITLE
fix(testimonials avatar)

### DIFF
--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import NextImage from "next/image";
+import NextImage, { StaticImageData } from "next/image";
 
 export type AvatarType = "container" | "initials" | "image";
 export type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl";
@@ -11,7 +11,8 @@ interface AvatarProps {
   variant?: AvatarVariant;
   initials?: string;
   disabled?: boolean;
-  imageUrl?: string;
+  imageUrl?: string | StaticImageData;
+  alt?: string;
   className?: string;
 }
 
@@ -52,6 +53,7 @@ export const Avatar = ({
   initials,
   disabled,
   imageUrl,
+  alt = "avatar",
   className,
 }: AvatarProps) => {
   const commonStyles = clsx(
@@ -67,7 +69,9 @@ export const Avatar = ({
   const styles = {
     backgroundColor: disabled
       ? "var(--color-avatar-default-disabled)"
-      : bg,
+      : type === "image"
+        ? "transparent"
+        : bg,
     color:
       variant === "default"
         ? "var(--color-avatar-default-text)"
@@ -85,10 +89,11 @@ export const Avatar = ({
       {type === "image" && imageUrl && (
         <NextImage
           src={imageUrl}
-          alt="avatar"
+          alt={alt}
+          fill
           className="object-cover w-full h-full"
-          width={200}
-          height={200}
+          priority={false}
+          sizes={`${sizeClasses[size]}`}
         />
       )}
     </div>

--- a/src/sections/TestimonialsSection/elements/TestimonialCard.tsx
+++ b/src/sections/TestimonialsSection/elements/TestimonialCard.tsx
@@ -1,31 +1,27 @@
-import Image, { StaticImageData } from "next/image";
+import Avatar from "@/components/ui/avatar";
+import { StaticImageData } from "next/image";
 
 export type Testimonials = {
     id: string;
-    image: string | StaticImageData ;
+    image: string | StaticImageData;
     name: string;
     quote: string;
     role: string;
 };
 
-interface TestimonialCardProps {
-    testimonial: Testimonials
-}
-
-export const TestimonialsCard = ({ testimonial }: TestimonialCardProps) => {
-    const { image, name, quote, role } = testimonial
+export const TestimonialsCard = ({ testimonial }: { testimonial: Testimonials }) => {
+    const { image, name, quote, role } = testimonial;
 
     return (
         <div className="flex flex-col justify-center items-center gap-8 w-[584px]">
             <p className="self-stretch text-size-500 font-heavy font-secondary text-black leading-line-height-body-1 text-center">
                 {quote}
             </p>
-            <Image
-                src={image}
+            <Avatar
+                type="image"
+                size="xl"
+                imageUrl={image}
                 alt={name}
-                width={96}
-                height={96}
-                className="rounded-full object-cover"
             />
             <div className="flex flex-col items-center justify-center text-black self-stretch text-center text-size-400">
                 <p className="font-primary font-heavy leading-line-height-body-3 ">


### PR DESCRIPTION
Refactors the Avatar component and integrates it into TestimonialsCard so testimonial photos render once, match DS size tokens, and load optimally with next/image.

**What’s included**

_Avatar_
- imageUrl now supports string | StaticImageData (works with /public paths and imported assets).
- Token → px map for next/image sizes when using fill (better resolution and loading).
- Transparent background when type="image" to avoid the colored circle behind photos.
- Keeps DS size tokens (xs | sm | md | lg | xl) via Tailwind classes.

_TestimonialsCard_
- Replaces standalone <Image> with <Avatar type="image">.