### PR TITLE
fix(card, impact): add variant and apply to Impact section

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -171,6 +171,10 @@ const cardDescriptionVariants = cva(
                 white: 'text-[var(--color-card-white-description)]',
                 purple: 'text-[var(--color-card-non-clickable-purple-description)]',
                 lightPurple: 'text-[var(--color-card-non-clickable-light-purple-description)]'
+            },
+            tone: {
+                default: '',
+                impact: ''
             }
         },
         compoundVariants: [
@@ -179,9 +183,15 @@ const cardDescriptionVariants = cva(
                 color: 'white',
                 class: 'text-[var(--color-card-white-title)]'
             },
+            {
+                tone: 'impact',
+                color: 'white',
+                class: 'text-[var(--color-card-white-title)]'
+            }
         ],
         defaultVariants: {
-            color: 'white'
+            color: 'white',
+            tone: 'default'
         }
     }
 );
@@ -193,6 +203,7 @@ type BaseProps = React.HTMLAttributes<HTMLDivElement> & {
     state?: 'default' | 'hover' | 'disabled';
     radius?: 'sm' | 'md' | 'lg';
     corner?: Corner;
+    tone?: 'default' | 'impact';
 };
 
 type ClickableCardProps = {
@@ -255,6 +266,7 @@ export const Card: React.FC<CardProps> = (props) => {
         description,
         icon,
         className,
+        tone='default',
         ...rest
     } = props as any;
 
@@ -322,7 +334,7 @@ export const Card: React.FC<CardProps> = (props) => {
                         </h3>
                     )}
                     {description && (
-                        <p className={cardDescriptionVariants({ color, type })}>
+                        <p className={cardDescriptionVariants({ color, type, tone })}>
                             {description}
                         </p>
                     )}

--- a/src/sections/ImpactSection/ImpactSection.tsx
+++ b/src/sections/ImpactSection/ImpactSection.tsx
@@ -1,4 +1,3 @@
-import styles from './impactSection.module.css';
 import SectionWrapper from '@/components/layout/section-wrapper/SectionWrapper'
 import { Card } from '@/components/ui/card'
 
@@ -6,22 +5,22 @@ const impactProps = [
   {
     title: "100+",
     description:
-      "women joined the community in our first month"
+      "Women joined the community in our first month"
   },
   {
     title: "3+",
     description:
-      "active teams working across design, dev, product, and more"
+      "Active teams working across design, dev, product, and more"
   },
   {
     title: "760+",
     description:
-      "hours invested by contributors in real workflows"
+      "Hours invested by contributors in real workflows"
   },
   {
     title: "5+",
     description:
-      "interviews landed by contributors in our first month"
+      "Interviews landed by contributors in our first month"
   }
 ]
 
@@ -43,7 +42,7 @@ export const ImpactSection = () => {
             description={item.description}
             color='white'
             radius='lg'
-            className={styles.impactCard}
+            tone='impact'
           />
         ))}
       </div>

--- a/src/sections/ImpactSection/impactSection.module.css
+++ b/src/sections/ImpactSection/impactSection.module.css
@@ -1,9 +1,0 @@
-.impactCard h3 {
-    font-size: var(--text-size-700) !important;
-    line-height: var(--spacing-line-height-heading-4)
-}
-
-.impactCard p {
-    color: var(--color-card-white-title) !important;
-    line-height: var(--spacing-line-height-body-3) !important;
-}


### PR DESCRIPTION
Introduce an opt-in `tone="impact"` on `Card` and apply it only in the Our Impact section to match UX. Title keeps the **default nonClickable** typography; only the description is adjusted. Removes the previous per-section CSS override.

**What’s included**

_Card_
- New optional tone prop: `'default' | 'impact'`.
- `tone="impact"` now only affects the description:
      - Description color uses title token (black on white scheme).
      - Description line-height set to body-3 token.
- No change to title sizing (stays as the default for nonClickable).
- No breaking changes; defaults unchanged when tone isn’t provided.

_ImpactSection_
- Pass `tone="impact"` to nonClickable cards to achieve the UX typography.
- Remove `ImpactSection.module.css` and related class usage (no more per-section `CSS).`