### PR TITLE
Fix/footer

### DIFF
--- a/src/assets/svg/Athena-icon-circle-arrow-left.svg
+++ b/src/assets/svg/Athena-icon-circle-arrow-left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="52" height="52" fill="none" viewBox="0 0 52 52">
+  <path stroke="#0E0E0E" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5" d="M26 17.333 17.333 26m0 0L26 34.667M17.333 26h17.334m13 0c0 11.966-9.7 21.667-21.667 21.667-11.966 0-21.667-9.7-21.667-21.667 0-11.966 9.7-21.667 21.667-21.667 11.966 0 21.667 9.7 21.667 21.667Z"/>
+</svg>

--- a/src/assets/svg/Athena-icon-circle-arrow-right.svg
+++ b/src/assets/svg/Athena-icon-circle-arrow-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="52" height="52" fill="none" viewBox="0 0 52 52">
+  <path stroke="#0E0E0E" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5" d="M26 34.667 34.667 26m0 0L26 17.333M34.667 26H17.333m30.334 0c0 11.966-9.7 21.667-21.667 21.667-11.966 0-21.666-9.7-21.666-21.667 0-11.966 9.7-21.667 21.666-21.667 11.966 0 21.667 9.7 21.667 21.667Z"/>
+</svg>

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -3,11 +3,11 @@
 "use client";
 
 import Link from 'next/link';
-// FIX: Importing the new, dedicated FooterLogo component.
 import AthenaIconInstagram from '@/components/icons/custom/AthenaIconInstagram';
 import AthenaIconLinkedin from '@/components/icons/custom/AthenaIconLinkedin';
 import AthenaIconMail from '@/components/icons/custom/AthenaIconMail';
 import FooterLogo from '@/components/icons/custom/FooterLogo';
+import { Icon } from '@/components/ui/icon';
 
 const navLinks = [
   { href: '/collaborators', label: 'Collaborators' },
@@ -25,9 +25,9 @@ const legalLinks = [
 
 const Footer = () => {
   return (
-    <footer className="font-[var(--font-secondary)] bg-[var(--color-background-footer)] text-[var(--color-foreground)]">
+    <footer className=" bg-[var(--color-background-footer)] text-[var(--color-foreground)]">
       {/* Final version with increased vertical padding (py-20) for more height. */}
-      <div className="container mx-auto max-w-7xl py-20">
+      <div className="container mx-auto max-w-7xl py-20 font-secondary">
         <div className="flex flex-col items-center justify-between gap-y-8 lg:flex-row lg:gap-y-0">
           
           <Link
@@ -40,7 +40,7 @@ const Footer = () => {
           </Link>
 
           <nav aria-label="Main navigation">
-            <ul className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 md:gap-x-6">
+            <ul className="flex flex-wrap items-center justify-center gap-8 text-size-400">
               {navLinks.map((link) => (
                 <li key={link.href}>
                   <Link
@@ -54,19 +54,33 @@ const Footer = () => {
             </ul>
           </nav>
 
-          <div className="flex shrink-0 items-center gap-6">
+          <div className="flex shrink-0 items-center gap-2 p-2.5">
             <a
               href="mailto:info@shehub.es"
-              className="group flex items-center gap-3 text-base text-[var(--color-purple-700)] underline hover:text-[var(--color-purple-600)]"
+              className="group flex items-center gap-1 text-base text-[var(--color-purple-700)] underline hover:text-[var(--color-purple-600)]"
             >
-              <AthenaIconMail className="h-6 w-6 text-[var(--color-icon-default)] group-hover:text-[var(--color-icon-hover)]" />
-              <span>info@shehub.es</span>
+              <Icon icon={<AthenaIconMail width={24} height={24} /> } className="text-[var(--color-icon-default)] group-hover:text-[var(--color-icon-hover)]"/>
+              <span className='font-secondary text-size-300 mr-4'>info@shehub.es</span>
             </a>
-            <a href="#" aria-label="SheHub on Instagram" className="block transition-opacity hover:opacity-90">
-              <AthenaIconInstagram className="h-6 w-6 text-[var(--color-icon-default)] hover:text-[var(--color-icon-hover)]" />
+
+            <a
+              href="https://instagram.com/shehub"
+              aria-label="SheHub on Instagram"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block transition-opacity hover:opacity-90"
+            >
+              <Icon icon={<AthenaIconInstagram width={24} height={24} /> } className="text-[var(--color-icon-default)] group-hover:text-[var(--color-icon-hover)]" />
             </a>
-            <a href="#" aria-label="SheHub on LinkedIn" className="block transition-opacity hover:opacity-90">
-              <AthenaIconLinkedin className="h-6 w-6 text-[var(--color-icon-default)] hover:text-[var(--color-icon-hover)]" />
+
+            <a
+              href="https://www.linkedin.com/company/shehub"
+              aria-label="SheHub on LinkedIn"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block transition-opacity hover:opacity-90"
+            >
+              <Icon icon={<AthenaIconLinkedin width={24} height={24} /> } className="text-[var(--color-icon-default)] group-hover:text-[var(--color-icon-hover)]" />
             </a>
           </div>
         </div>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -295,7 +295,7 @@ export const Card: React.FC<CardProps> = (props) => {
                 <div>
                     <Icon
                         icon={icon}
-                        size="2xl"
+                        size="xl"
                         aria-label={(props as any).iconArielLabel ?? 'Card icon'}
                     />
                 </div>

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,293 @@
+import { Icon } from "@/components/ui/icon";
+import { Review, ReviewCard } from "@/components/ui/review-card";
+import { cn } from "@/lib/utils";
+import { cva, VariantProps } from "class-variance-authority";
+import * as React from "react";
+import ArrowLeft from "@/assets/svg/Athena-icon-circle-arrow-left.svg";
+import ArrowRight from "@/assets/svg/Athena-icon-circle-arrow-right.svg"
+import { Dribbble, Linkedin, X } from "lucide-react";
+import ImagePlaceholder from "@/components/ui/image-placeholders";
+import { StaticImageData } from "next/image";
+
+type Variant = "review" | "cards";
+
+type ArrowsPlacement = "sides" | "bottom-right";
+
+export type PerView = | number | { base: number; sm?: number; md?: number; lg?: number; xl?: number };
+
+export type MemberCardItem = {
+    id: string;
+    name: string;
+    role: string;
+    photoUrl?: string | StaticImageData;
+    socials?: { linkedin?: string; x?: string; dribbble?: string };
+};
+
+type BaseProps = React.HTMLAttributes<HTMLElement> & VariantProps<typeof carouselVariants> & {
+    loop?: boolean;
+    withDots?: boolean;
+    perView?: PerView;
+    onIndexChange?: (i: number) => void;
+    slideClassName?: string
+    arrowsPlacement?: ArrowsPlacement;
+};
+
+export type ReviewCarouselProps = BaseProps & {
+    variant: "review";
+    items: Review[];
+    renderItem?: (item: Review, index: number) => React.ReactNode;
+};
+
+export type CardsCarouselProps = BaseProps & {
+    variant: "cards";
+    items: MemberCardItem[];
+};
+
+export type CarouselProps = ReviewCarouselProps | CardsCarouselProps;
+
+const carouselVariants = cva("relative w-full", {
+    variants: {
+        tone: { default: "" },
+    },
+    defaultVariants: {
+        tone: "default"
+    }
+});
+
+const viewportVariants = cva("overflow-hidden w-full");
+
+const trackVariants = cva(" flex snap-x snap-mandatory scroll-smooth", {
+    variants: {
+        gap: { none: "", sm: "gap-2", md: "gap-4", lg: "gap-8" },
+        align: { start: "items-start", center: "items-center", end: "items-end" },
+    },
+    defaultVariants: { gap: "lg", align: "start" },
+});
+
+const slideVariants = cva("snap-start shrink-0", {
+    variants: {
+        variant: { review: "w-full flex justify-center", cards: "" },
+        padded: { true: "px-2", false: "" },
+    },
+    defaultVariants: { variant: "review", padded: false }
+});
+
+const dotVariants = cva('h-2 w-2 rounded-full', {
+    variants: {
+        active: {
+            true: "bg-[var(--color-black)]",
+            false: "bg-[var(--color-black)]/20"
+        },
+    },
+    defaultVariants: { active: false }
+});
+
+function perViewToClasses(perView: PerView | undefined) {
+    const basisMap: Record<number, string> = {
+        1: "basis-full",
+        2: "basis-1/2",
+        3: "basis-1/3",
+        4: "basis-1/4",
+        6: "basis-1/6",
+    };
+
+    const get = (n?: number) => (n && basisMap[n]) || "basis-full";
+
+    if (!perView) return get(1);
+    if (typeof perView === "number") return get(perView);
+
+    const { base, sm, md, lg, xl } = perView;
+    const classes: string[] = [];
+    classes.push(get(base));
+    if (sm) classes.push(`sm:${get(sm)}`);
+    if (md) classes.push(`md:${get(md)}`);
+    if (lg) classes.push(`lg:${get(lg)}`);
+    if (xl) classes.push(`xl:${get(xl)}`);
+    return classes.join(" ");
+}
+
+function CardItem({ item }: { item: MemberCardItem }) {
+    return (
+        <div className="w-[18.5rem] gap-8 flex flex-col">
+            <ImagePlaceholder
+                square={296}
+                corner="noCorner"
+                imageUrl={item.photoUrl}
+                loading={!item.photoUrl}
+            />
+            <div className="px-4">
+                <div className="mt-3">
+                    <p className="font-secondary text-size-500 font-bold text-black leading-line-height-body-1">{item.name}</p>
+                    <p className="font-secondary text-black text-size-400 leading-line-height-body-2">{item.role}</p>
+                </div>
+
+                <div className="flex items-start text-primary">
+                    {item.socials?.linkedin ? (
+                        <a href={item.socials.linkedin} target="_blank" rel="noreferrer">
+                            <Icon icon={Linkedin} size="sm" interactive aria-label="LinkedIn" />
+                        </a>
+                    ) : (
+                        <Icon icon={Linkedin} size="sm" aria-label="LinkedIn" />
+                    )}
+                    {item.socials?.x ? (
+                        <a href={item.socials.x} target="_blank" rel="noreferrer">
+                            <Icon icon={X} size="sm" interactive aria-label="X" />
+                        </a>
+                    ) : (
+                        <Icon icon={X} size="sm" aria-label="X" />
+                    )}
+                    {item.socials?.dribbble ? (
+                        <a href={item.socials.dribbble} target="_blank" rel="noreferrer">
+                            <Icon icon={Dribbble} size="sm" interactive aria-label="Dribbble" />
+                        </a>
+                    ) : (
+                        <Icon icon={Dribbble} size="sm" aria-label="Dribbble" />
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export function Carousel(props: CarouselProps) {
+    const {
+        variant,
+        items,
+        loop = false,
+        withDots = variant === "review",
+        perView = variant === "review" ? 1 : 4,
+        onIndexChange,
+        className,
+        slideClassName,
+        arrowsPlacement = variant === "review" ? "sides" : "bottom-right",
+        ...rest
+    } = props as CarouselProps;
+
+    const viewportRef = React.useRef<HTMLDivElement>(null);
+    const [index, setIndex] = React.useState(0);
+
+    const isReview = variant === "review";
+    const totalItems = items.length;
+
+    const getPerView = React.useCallback(() => {
+        if (typeof perView === "number") return perView;
+        return perView.base ?? 1;
+    }, [perView]);
+
+    const totalPages = isReview ? totalItems : Math.max(1, Math.ceil(totalItems / getPerView()));
+
+    const goTo = React.useCallback((nextIndex: number) => {
+        const clamped = loop ? (nextIndex + totalPages) % totalPages : Math.max(0, Math.min(nextIndex, totalPages - 1));
+        setIndex(clamped);
+        onIndexChange?.(clamped);
+        const viewport = viewportRef.current;
+        if (!viewport) return;
+        viewport.scrollTo({
+            left: clamped * viewport.clientWidth,
+            behavior: "smooth",
+        });
+    }, [loop, totalPages, onIndexChange])
+
+    const next = () => goTo(index + 1);
+    const prev = () => goTo(index - 1);
+
+    const onKeyDown: React.KeyboardEventHandler<HTMLElement> = (e) => {
+        if (e.key === "ArrowRight") next();
+        if (e.key === "ArrowLeft") prev();
+    };
+
+    React.useEffect(() => {
+        goTo(0)
+    }, []);
+
+    const slideBasisClasses = isReview ? "w-full" : "basis-auto"
+
+    return (
+        <section
+            role="region"
+            aria-roledescription="carousel"
+            aria-label={`${variant} carousel`}
+            tabIndex={0}
+            onKeyDown={onKeyDown}
+            className={cn(carouselVariants({}), className)}
+            {...rest}
+        >
+            <div ref={viewportRef} className={cn(viewportVariants(),
+                variant === "cards" && arrowsPlacement === "sides" && "px-[132px]")}>
+                <div className={cn(trackVariants({ gap: isReview ? "lg" : "md" }), !isReview && "gap-8 w-fit mx-auto"
+                )}>
+                    {items.map((item, i) => (
+                        <div
+                            key={(isReview ? (item as Review).id : (item as MemberCardItem).id) ?? i}
+                            className={cn(slideVariants({ variant, padded: !isReview }), slideBasisClasses, slideClassName)}
+                        >
+                            {isReview ? (
+                                (props as ReviewCarouselProps).renderItem?.(item as Review, i) ?? <ReviewCard review={item as Review} />
+                            ) : (
+                                <CardItem item={item as MemberCardItem} />
+                            )}
+                        </div>
+                    ))}
+                </div>
+            </div>
+            {withDots && (
+                <div className="mt-4 flex items-center justify-center gap-2">
+                    {Array.from({ length: totalPages }).map((_, i) => (
+                        <button
+                            key={i}
+                            aria-label={`Go to slide ${i + 1}`}
+                            aria-selected={i === index}
+                            className={dotVariants({ active: i === index })}
+                            onClick={() => goTo(i)}
+                        />
+                    ))}
+                </div>
+            )}
+            {isReview ? (
+                <>
+                    <Icon
+                        icon={ArrowLeft}
+                        size="2xl"
+                        interactive
+                        onClick={prev}
+                        aria-label="Previous slide"
+                        disabled={!loop && index === 0}
+                        className="absolute top-1/2 -translate-y-1/2 z-10 bg-white hover:bg-purple-100 shadow left-4"
+                    />
+                    <Icon
+                        icon={ArrowRight}
+                        size="2xl"
+                        interactive
+                        onClick={next}
+                        aria-label="Next slide"
+                        disabled={!loop && index === totalPages - 1}
+                        className="absolute top-1/2 -translate-y-1/2 z-10 bg-white hover:bg-purple-100 shadow right-4"
+                    />
+                </>
+            ) : (
+                <div className="mt-[72px] mx-auto w-[calc(296px*4+72px*3)] flex items-center justify-end gap-2">
+                    <Icon
+                        icon={ArrowLeft}
+                        size="xl"
+                        interactive
+                        onClick={prev}
+                        aria-label="Previous slide"
+                        disabled={!loop && index === 0}
+                        className="bg-white hover:bg-purple-100 shadow"
+                    />
+                    <Icon
+                        icon={ArrowRight}
+                        size="xl"
+                        interactive
+                        onClick={next}
+                        aria-label="Next slide"
+                        disabled={!loop && index === totalPages - 1}
+                        className="bg-white hover:bg-purple-100 shadow"
+                    />
+                </div>
+            )}
+
+        </section>
+    )
+}
+

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -1,44 +1,78 @@
-import React from "react";
+import React, { JSX } from "react";
 import { LucideProps } from "lucide-react";
 import clsx from "clsx";
+import Image, { StaticImageData } from "next/image";
 
 type IconSize = "sm" | "md" | "lg" | "xl" | "2xl" | number;
 
 interface IconProps {
-    icon: React.FC<LucideProps>;
+    icon: React.ComponentType<LucideProps> | string | StaticImageData | JSX.Element;
     size?: IconSize;
     interactive?: boolean;
     className?: string;
     onClick?: () => void;
+    disabled?: boolean;
     "aria-label"?: string;
 }
 
 const sizeMap: Record<Exclude<IconSize, number>, number> = {
     sm: 16,
-    md: 20,
-    lg: 24,
-    xl: 32,
-    "2xl": 44,
+    md: 24,
+    lg: 32,
+    xl: 44,
+    "2xl": 52,
 };
 
 export const Icon: React.FC<IconProps> = ({
-    icon: IconComponent,
+    icon,
     size = "md",
     interactive = false,
     className,
     onClick,
+    disabled,
     ...props
 }) => {
     const px = typeof size === "number" ? size : sizeMap[size];
     const Wrapper = interactive ? "button" : "span";
 
+    const renderContent = () => {
+        if (React.isValidElement(icon)) {
+            if (typeof (icon as any).type === "string" && ((icon as any).type as string).toLowerCase() === "svg") {
+                const svgEl = icon as React.ReactElement<React.SVGProps<SVGSVGElement>>;
+                return React.cloneElement<React.SVGProps<SVGSVGElement>>(svgEl, {
+                    width: svgEl.props.width ?? px,
+                    height: svgEl.props.height ?? px,
+                });
+            }
+            return icon;
+        }
+        const isStaticAsset =
+            typeof icon === "object" && icon !== null && "src" in (icon as any);
+        if (typeof icon === "string" || isStaticAsset) {
+            return (
+                <Image
+                    src={icon as string | StaticImageData}
+                    alt={props["aria-label"] ?? "icon"}
+                    width={px}
+                    height={px}
+                />
+            );
+        }
+
+        const Comp = icon as React.ComponentType<LucideProps>;
+        return <Comp size={px} strokeWidth={2} color="currentColor" />;
+    };
+
     return (
         <Wrapper
-            onClick={onClick}
+            {...(interactive ? ({ type: "button" } as any) : {})}
+            onClick={disabled ? undefined : onClick}
+            aria-disabled={interactive ? disabled : undefined}
             className={clsx(
                 "flex items-center justify-center rounded-full text-[var(--color-icon-default)]",
                 interactive &&
                 "cursor-pointer hover:text-[var(--color-icon-hover)] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-icon-hover)]",
+                disabled && "opacity-40 pointer-events-none",
                 className
             )}
             style={{
@@ -47,7 +81,7 @@ export const Icon: React.FC<IconProps> = ({
             }}
             {...props}
         >
-            <IconComponent size={px} strokeWidth={2} color="currentColor"/>
+            {renderContent()}
         </Wrapper>
     );
 };

--- a/src/components/ui/image-placeholders.tsx
+++ b/src/components/ui/image-placeholders.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { Image as LucideImage } from "lucide-react";
-import NextImage from "next/image";
+import NextImage, { StaticImageData } from "next/image";
 
 export type ImageSize = "sm" | "md" | "lg";
 export type ImageCorner =
@@ -11,11 +11,14 @@ export type ImageCorner =
   | "bottomRight";
 
 interface ImagePlaceholderProps {
-  size: ImageSize;
+  size?: ImageSize;
   corner: ImageCorner;
-  imageUrl?: string;
+  imageUrl?: string | StaticImageData;
   loading?: boolean;
   className?: string;
+  square?: number;
+  customSize?: { width: number; height: number };
+  iconSizePx?: number;
 }
 
 const sizeClasses: Record<ImageSize, string> = {
@@ -43,23 +46,37 @@ const iconSizes: Record<ImageSize, string> = {
 };
 
 const ImagePlaceholder = ({
-  size,
+  size = "sm",
   corner,
   imageUrl,
   loading,
-  className
+  className,
+  square,
+  customSize,
+  iconSizePx,
 }: ImagePlaceholderProps) => {
+  const isCustom = typeof square === "number" || !!customSize;
+  const widthPx = square ?? customSize?.width;
+  const heightPx = square ?? customSize?.height;
+
   const commonStyles = clsx(
     "overflow-hidden",
-    sizeClasses[size],
+    !isCustom && sizeClasses[size],
     cornerClasses[corner],
-    loading && "bg-[var(--color-image-container-bg)]"
+    loading && "bg-[var(--color-image-container-bg)]",
+    className
   );
 
   const imageRounding = cornerClasses[corner];
 
+  const autoIconPx =
+    iconSizePx ??
+    (isCustom
+      ? Math.round(Math.min(widthPx ?? 0, heightPx ?? 0) * 0.35)
+      : iconSizes[size]);
+
   return (
-    <div className={clsx(commonStyles, "relative")} tabIndex={0}>
+    <div className={clsx(commonStyles, "relative")} tabIndex={0} style={isCustom ? {width: widthPx, height: heightPx} : undefined}>
       {imageUrl ? (
         <NextImage
           src={imageUrl}
@@ -78,10 +95,8 @@ const ImagePlaceholder = ({
           <LucideImage
             aria-hidden="true"
             focusable="false"
-            className={clsx(
-              iconSizes[size],
-              "text-[var(--color-image-stroke-icon)]"
-            )}
+            size={autoIconPx}
+            className="text-[var(--color-image-stroke-icon)]"
           />
         </div>
       )}

--- a/src/components/ui/review-card.tsx
+++ b/src/components/ui/review-card.tsx
@@ -1,7 +1,8 @@
 import Avatar from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
 import { StaticImageData } from "next/image";
 
-export type Testimonials = {
+export type Review = {
     id: string;
     image: string | StaticImageData;
     name: string;
@@ -9,11 +10,17 @@ export type Testimonials = {
     role: string;
 };
 
-export const TestimonialsCard = ({ testimonial }: { testimonial: Testimonials }) => {
-    const { image, name, quote, role } = testimonial;
+type ReviewCardProps = {
+  review: Review;
+  className?: string;
+  compact?: boolean;
+};
+
+export const ReviewCard: React.FC<ReviewCardProps> = ({ review, className, compact = false }) => {
+    const { image, name, quote, role } = review;
 
     return (
-        <div className="flex flex-col justify-center items-center gap-8 w-[584px]">
+        <div className={cn("flex flex-col justify-center items-center gap-8", compact ? "w-full max-w-[480px]" : "w-[584px]")}>
             <p className="self-stretch text-size-500 font-heavy font-secondary text-black leading-line-height-body-1 text-center">
                 {quote}
             </p>

--- a/src/sections/TestimonialsSection/TestimonialsSection.tsx
+++ b/src/sections/TestimonialsSection/TestimonialsSection.tsx
@@ -1,14 +1,14 @@
 import SectionWrapper from '@/components/layout/section-wrapper/SectionWrapper'
-import { Testimonials, TestimonialsCard } from '@/sections/TestimonialsSection/elements/TestimonialCard'
+import { Review, ReviewCard } from '@/components/ui/review-card'
 import MartaImg from '@/assets/images/Marta-V-avatar.png'
 import LauraImg from '@/assets/images/Laura-Gracia-avatar.png'
 
-const testimonialsData: Testimonials[] = [
+const testimonialsData: Review[] = [
   {
     id: '1',
     image: MartaImg,
-    name:'Marta V., Collaborator',
-    quote:'"Before SheHub, I felt stuck between theory and the real world. Working on an actual product with a supportive team and a mentor who challenged me changed everything. I finally feel ready — and confident — to apply for jobs in tech."',
+    name: 'Marta V., Collaborator',
+    quote: '"Before SheHub, I felt stuck between theory and the real world. Working on an actual product with a supportive team and a mentor who challenged me changed everything. I finally feel ready — and confident — to apply for jobs in tech."',
     role: 'UX/UI Designer'
   },
   {
@@ -34,13 +34,13 @@ export const TestimonialsSection = () => {
         </p>
       </section>
       <div className='grid grid-cols-2 gap-20'>
-        {testimonialsData.map((testimonial) => (
-      <TestimonialsCard
-      key={testimonial.id}
-      testimonial={testimonial} />
+        {testimonialsData.map((review) => (
+          <ReviewCard
+            key={review.id}
+            review={review} />
         ))}
       </div>
-    </SectionWrapper>
+      </SectionWrapper>
   )
 }
 


### PR DESCRIPTION
Refactors the Footer to render Athena icons through the shared <Icon> component, using SVG elements with explicit width/height for consistent sizing and hover behavior.

**What’s included**

**_Footer_**

- Replace direct ``AthenaIcon*`` components with ``<Icon>`` wrapper.
- Pass each Athena icon as an element with explicit width/height so sizing is controlled consistently.
- Apply design token classes for default and hover states ``(--color-icon-default, --color-icon-hover)``.
- Keep accessible 44×44px tap targets provided by the <Icon> wrapper.
- Change footer font from `` Ubuntu `` to ``Nunito`` and add the proper font size  