### PR TITLE
fix(build): allow Next.js production build with ESLint errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,9 @@ const nextConfig: NextConfig = {
       "randomuser.me"
     ],
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Enables eslint.ignoreDuringBuilds in ``next.config.ts`` so next build doesn’t fail on ESLint errors in CI. This is a temporary unblocker to get Vercel deploys green while we address the pending lint fixes in follow-up PRs.

**_Why_**
Vercel runs next build, which executes ESLint and aborts on errors. We need successful Preview/Production deployments while we address linting separately.

_**Impact**_
- Vercel builds and deploys succeed.
- Lint errors won’t block CI until we revert this setting.
- No runtime, UI, or dependency changes.

**_Follow-ups (separate PRs)_**
- Fix existing ESLint errors/warnings across the codebase.
- Remove ``ignoreDuringBuilds`` to restore strict CI once lint is clean.

**_Rollback_**
- Delete the ``eslint.ignoreDuringBuilds`` block from next.config.mjs.