### PR TITLE
fix(routing): join CTAs, heritage journey WIP, forms & contact polish

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -2,6 +2,7 @@
 
 import IconMail from "@/components/icons/IconMail";
 import Button from "@/components/ui/Button";
+import { CopyEmailTrigger } from "@/components/ui/CopyEmailTrigger";
 import Checkbox from "@/components/ui/Checkbox";
 import { Icon } from "@/components/ui/Icon";
 import { Input } from "@/components/ui/Input";
@@ -78,13 +79,10 @@ export default function ContactPage() {
             </p>
 
             <div className="flex items-center justify-center md:justify-start gap-3">
-              <Icon icon={IconMail} size="md" className="text-icon-default" aria-hidden="true" />
-              <a
-                href="mailto:info@shehub.es"
-                className="text-primary font-medium hover:underline"
-              >
-                info@shehub.es
-              </a>
+              <CopyEmailTrigger className="inline-flex items-center gap-3 cursor-pointer bg-transparent border-0 p-0 text-left font-inherit text-primary font-medium hover:underline">
+                <Icon icon={IconMail} size="md" className="text-icon-default shrink-0" aria-hidden="true" />
+                <span>info@shehub.es</span>
+              </CopyEmailTrigger>
             </div>
           </div>
 

--- a/src/app/heritage/[era]/page.tsx
+++ b/src/app/heritage/[era]/page.tsx
@@ -1,0 +1,43 @@
+import { HERITAGE_ERA_SLUGS, isHeritageEraSlug, type HeritageEraSlug } from '@/data/heritage'
+import HeritageEraTeamContent from '@/sections/heritage/HeritageEraTeamContent'
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+const TEAM_PAGE_TITLE: Record<HeritageEraSlug, string> = {
+  teaser: 'Equipo · Teaser | SheHub',
+  intermediate: 'Equipo · Sitio intermedio | SheHub',
+  current: 'Equipo · Sitio actual | SheHub',
+}
+
+const TEAM_PAGE_DESCRIPTION: Record<HeritageEraSlug, string> = {
+  teaser: 'Personas que participaron en la teaser inicial del sitio SheHub, por rol.',
+  intermediate: 'Personas que participaron en la segunda versión del sitio SheHub, por rol.',
+  current: 'Personas que participan en la web actual y design system de SheHub, por rol.',
+}
+
+type Props = {
+  params: Promise<{ era: string }>
+}
+
+export function generateStaticParams() {
+  return HERITAGE_ERA_SLUGS.map((era) => ({ era }))
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { era } = await params
+  if (!isHeritageEraSlug(era)) {
+    return {}
+  }
+  return {
+    title: TEAM_PAGE_TITLE[era],
+    description: TEAM_PAGE_DESCRIPTION[era],
+  }
+}
+
+export default async function HeritageEraPage({ params }: Props) {
+  const { era } = await params
+  if (!isHeritageEraSlug(era)) {
+    notFound()
+  }
+  return <HeritageEraTeamContent era={era} />
+}

--- a/src/app/heritage/page.tsx
+++ b/src/app/heritage/page.tsx
@@ -1,0 +1,12 @@
+import HeritagePageContent from '@/sections/heritage/HeritagePageContent'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Recorrido web',
+  description:
+    'Cómo ha evolucionado la presencia online de SheHub: teaser inicial, sitio intermedio y la web actual con design system.',
+}
+
+export default function HeritagePage() {
+  return <HeritagePageContent />
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
     template: "%s | SheHub",
   },
   description:
-    "SheHub conecta a recién graduadas y profesionales que buscan su primera experiencia en tech con mentoras con experiencia para trabajar en proyectos reales. Mentoría, experiencia y comunidad sin coste. Empoderamos a mujeres en tech, diseño e innovación digital.",
+    "SheHub conecta a recién graduadas y profesionales que buscan su primera experiencia en tech con mentoras con experiencia para trabajar en proyectos reales. Mentoría, experiencia práctica y comunidad tech. Empoderamos a mujeres en tech, diseño e innovación digital.",
   keywords: [
     "mujeres en tech",
     "mentoría tech",
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "SheHub — Comunidad tech para mujeres",
     description:
-      "Conectamos a recién graduadas y a quienes buscan su primera experiencia en tech con mentoras para proyectos reales. Mentoría, experiencia y comunidad sin coste. Únete a SheHub.",
+      "Conectamos a recién graduadas y a quienes buscan su primera experiencia en tech con mentoras para proyectos reales. Mentoría, experiencia práctica y comunidad tech. Únete a SheHub.",
     url: "https://shehub.es",
     siteName: "SheHub",
     images: [
@@ -61,7 +61,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "SheHub — Comunidad tech para mujeres",
     description:
-      "Conectamos a recién graduadas y a quienes buscan su primera experiencia en tech con mentoras para proyectos reales. Mentoría, experiencia y comunidad sin coste.",
+      "Conectamos a recién graduadas y a quienes buscan su primera experiencia en tech con mentoras para proyectos reales. Mentoría, experiencia práctica y comunidad tech.",
   },
   robots: {
     index: true,

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -6,6 +6,7 @@ import IconLinkedIn from '@/components/icons/IconLinkedIn';
 import IconMail from '@/components/icons/IconMail';
 import { Icon } from '@/components/ui/Icon';
 import NavigationMenu from '@/components/ui/NavigationMenu';
+import { CopyEmailTrigger } from '@/components/ui/CopyEmailTrigger';
 import Link from 'next/link';
 
 const legalLinks = [
@@ -36,13 +37,10 @@ const Footer = () => {
           </div>
 
           <div className="flex flex-col lg:flex-row items-start lg:items-center lg:gap-2 px-4 lg:px-0">
-            <a
-              href="mailto:info@shehub.es"
-              className="group flex items-center lg:gap-1 text-base text-purple-700 underline hover:text-purple-600 pb-1 lg:pb-0"
-            >
-              <Icon icon={IconMail} size="md" className="text-icon-default group-hover:text-icon-hover"/>
-              <span className='font-secondary text-size-300 mr-4'>info@shehub.es</span>
-            </a>
+            <CopyEmailTrigger className="group inline-flex items-center lg:gap-1 text-base text-purple-700 underline hover:text-purple-600 pb-1 lg:pb-0 cursor-pointer bg-transparent border-0 p-0 text-left font-inherit">
+              <Icon icon={IconMail} size="md" className="text-icon-default group-hover:text-icon-hover shrink-0" aria-hidden />
+              <span className="font-secondary text-size-300 mr-4">info@shehub.es</span>
+            </CopyEmailTrigger>
 
             <div className="flex gap-2 pb-4 lg:pb-0">
               <a

--- a/src/components/ui/CopyEmailTrigger.tsx
+++ b/src/components/ui/CopyEmailTrigger.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import Button from '@/components/ui/Button'
+import { useTranslation } from '@/hooks/useTranslation'
+import { useCallback, useRef, useState } from 'react'
+
+export const SHEHUB_INFO_EMAIL = 'info@shehub.es'
+
+type CopyEmailTriggerProps = {
+  className?: string
+  children: React.ReactNode
+}
+
+export function CopyEmailTrigger({ className, children }: CopyEmailTriggerProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const [copied, setCopied] = useState(false)
+  const { t } = useTranslation()
+
+  const open = () => {
+    setCopied(false)
+    dialogRef.current?.showModal()
+  }
+
+  const close = useCallback(() => {
+    dialogRef.current?.close()
+    setCopied(false)
+  }, [])
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(SHEHUB_INFO_EMAIL)
+      setCopied(true)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={open}
+        className={className}
+        aria-haspopup="dialog"
+        title={t('copyEmail.openLabel')}
+      >
+        {children}
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        className="fixed left-1/2 top-1/2 z-100 w-[min(calc(100vw-2rem),22rem)] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-black/10 bg-white p-6 text-black shadow-xl backdrop:bg-black/40 open:flex open:flex-col open:gap-4"
+        onClick={(e) => {
+          if (e.target === dialogRef.current) close()
+        }}
+        aria-labelledby="copy-email-title"
+      >
+        <h2 id="copy-email-title" className="font-(--font-weight-heavy) text-lg text-black">
+          {t('copyEmail.title')}
+        </h2>
+        <p className="text-sm leading-relaxed text-gray-700 font-secondary">
+          {t('copyEmail.description')}
+        </p>
+        <p className="rounded-lg bg-purple-50 px-3 py-2 font-mono text-sm font-medium text-purple-900">
+          {SHEHUB_INFO_EMAIL}
+        </p>
+        {copied && (
+          <p className="text-sm font-medium text-green-700" role="status">
+            {t('copyEmail.copied')}
+          </p>
+        )}
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-3">
+          <Button type="button" variant="secondary-primary" shape="rounded" size="sm" onClick={close}>
+            {t('copyEmail.close')}
+          </Button>
+          <Button type="button" variant="primary-primary" shape="rounded" size="sm" onClick={copy}>
+            {t('copyEmail.copy')}
+          </Button>
+        </div>
+      </dialog>
+    </>
+  )
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "@/components/ui/Icon";
 import { cn } from "@/lib/utils";
 import { cva } from "class-variance-authority";
-import { useId, useRef, useState } from "react";
+import { useId, useRef } from "react";
 
 interface InputProps {
   id?: string;
@@ -39,13 +39,6 @@ const inputWrapperVariants = cva(
         false: "",
       },
     },
-    compoundVariants: [
-      {
-        status: "default",
-        disabled: false,
-        class: "hover:border-purple-600",
-      },
-    ],
     defaultVariants: {
       status: "default",
       disabled: false,
@@ -86,39 +79,20 @@ export const Input: React.FC<InputProps> = ({
   onChange,
   ...props
 }) => {
-  const [isSelected, setIsSelected] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const generatedId = useId();
   const inputId = id || generatedId;
   const helperId = helperText ? `${inputId}-helper` : undefined;
 
-  const selectedClasses =
-    isSelected && !disabled
-      ? {
-        default: "border-purple-800",
-        error: "border-error",
-        success: "border-success",
-      }[status]
-      : "";
+  const wrapStatus =
+    status === "default"
+      ? "sh-input-wrap--default"
+      : status === "error"
+        ? "sh-input-wrap--error"
+        : "sh-input-wrap--success";
 
   const labelClasses = `${disabled ? "text-neutral-600" : "text-black"} font-secondary text-base font-bold leading-6`;
-
-  const handleMouseDown = () => {
-    if (!disabled) {
-      setIsSelected(true);
-    }
-  };
-
-  const handleBlur = () => {
-    setIsSelected(false);
-  };
-
-  const handleFocus = () => {
-    if (!disabled) {
-      setIsSelected(true);
-    }
-  };
 
   //when tabbing the component the wrapper gets focused and pressing space/enter will focus the input
   const handleWrapperKeyDown = (e: React.KeyboardEvent) => {
@@ -143,10 +117,10 @@ export const Input: React.FC<InputProps> = ({
 
       <div
         className={cn(
+          "sh-input-wrap",
+          wrapStatus,
           inputWrapperVariants({ status, disabled }),
-          selectedClasses,
         )}
-        onMouseDown={handleMouseDown}
         onClick={handleWrapperClick}
         tabIndex={disabled ? -1 : 0} //make the wrapper focusable
         onKeyDown={handleWrapperKeyDown}
@@ -159,8 +133,6 @@ export const Input: React.FC<InputProps> = ({
           placeholder={placeholder}
           value={value}
           onChange={onChange}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
           disabled={disabled}
           className={cn(inputFieldVariants({ disabled }), inputClassName)}
           style={{

--- a/src/components/ui/NavigationMenu.tsx
+++ b/src/components/ui/NavigationMenu.tsx
@@ -9,6 +9,7 @@ const NavigationMenu = () => {
   const pathname = usePathname();
   const { t } = useTranslation();
 
+  // Recorrido: para volver a mostrarlo, añade { key: 'heritage.navLink', href: '/heritage' } al final del array (ruta viva: /heritage).
   const navItems = [
     { key: 'menu.item-1', href: '/collaborators' },
     { key: 'menu.item-2', href: '/mentors' },

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -36,22 +36,22 @@ const DropdownMenuTriggerButton = React.forwardRef<
           ref={ref}
           {...props}
           className={cn(
+            "shehub-dropdown-trigger",
             "inline-flex w-full items-center justify-between gap-2",
-            "h-10 rounded-md border bg-transparent px-3 text-sm",
+            "min-h-11 h-12 rounded-[12px] border bg-transparent px-3 text-base",
             "border-[var(--color-neutral-300)] text-[var(--color-foreground)]",
+            "font-secondary font-normal leading-6 text-[#0e0e0e]",
             "hover:border-[var(--color-primary)]/80",
-            "focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/60",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]",
-            "data-[state=open]:ring-2 data-[state=open]:ring-[var(--color-primary)]",
-            "data-[state=open]:ring-offset-2 data-[state=open]:ring-offset-background",
-            "transition-colors",
+            "outline-none focus:outline-none",
+            "data-[state=open]:border-[var(--color-primary)] data-[state=open]:border-2",
+            "transition-[border-color,box-shadow,background-color] duration-150",
             className
           )}
         >
           <span className={cn(!label && "text-[var(--color-neutral-500)]")}>
             {label || placeholder}
           </span>
-          <ChevronDown className="h-4 w-4 shrink-0 opacity-80" />
+          <ChevronDown className="h-6 w-6 shrink-0 opacity-80 text-[#0e0e0e]" aria-hidden />
         </button>
       </DropdownMenuTrigger>
     );
@@ -89,7 +89,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-[var(--color-neutral-300)] bg-white",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-[var(--color-neutral-300)] bg-[var(--dropdown-menu-bg-figma)]",
       "text-[var(--color-foreground)] shadow-lg",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
@@ -111,7 +111,13 @@ const DropdownMenuContent = React.forwardRef<
   }
 >(
   (
-    { className, sideOffset = 4, scrollMaxHeight = "max-h-60", ...props },
+    {
+      className,
+      sideOffset = 8,
+      scrollMaxHeight = "max-h-80",
+      children,
+      ...props
+    },
     ref
   ) => (
     <DropdownMenuPrimitive.Portal>
@@ -120,21 +126,26 @@ const DropdownMenuContent = React.forwardRef<
         side="bottom"
         align="start"
         sideOffset={sideOffset}
-        avoidCollisions={false}
+        collisionPadding={12}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border border-[var(--color-neutral-300)] bg-white p-1",
-          "text-[var(--color-foreground)] shadow-lg",
+          "z-50 outline-none",
           "data-[state=open]:animate-in data-[state=closed]:animate-out",
           "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
           "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
-          "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-          className
+          "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
         )}
         {...props}
       >
-        <div className={cn("overflow-y-auto", scrollMaxHeight)}>
-          {props.children}
+        <div
+          className={cn(
+            "min-w-[12rem] overflow-y-auto overflow-x-hidden rounded-md border border-[var(--color-neutral-300)] bg-[var(--dropdown-menu-bg-figma)] py-1.5 px-1 shadow-lg",
+            "text-[var(--color-foreground)]",
+            scrollMaxHeight,
+            className
+          )}
+        >
+          {children}
         </div>
       </DropdownMenuPrimitive.Content>
     </DropdownMenuPrimitive.Portal>
@@ -143,9 +154,9 @@ const DropdownMenuContent = React.forwardRef<
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const baseItem =
-  "relative flex cursor-default select-none items-center rounded-[6px] px-2 py-1.5 text-sm outline-none transition-colors " +
-  "data-[highlighted]:bg-[var(--color-primary)]/10 focus:bg-[var(--color-primary)]/10 " +
-  "data-[disabled]:pointer-events-none data-[disabled]:opacity-50 mx-1 my-1";
+  "relative flex min-h-12 cursor-default select-none items-center gap-3 rounded px-2 py-3 font-secondary text-base font-normal leading-6 text-[#0e0e0e] outline-none transition-colors " +
+  "data-[highlighted]:bg-[var(--dropdown-item-highlight-bg-figma)] data-[highlighted]:text-[#0e0e0e] " +
+  "data-[disabled]:pointer-events-none data-[disabled]:opacity-50";
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,

--- a/src/data/heritage/contributors.ts
+++ b/src/data/heritage/contributors.ts
@@ -1,0 +1,31 @@
+import type { HeritageContributor, HeritageEraSlug } from '@/data/heritage/types'
+
+/**
+ * Personas por etapa del sitio. Añade filas con `roleGroup` para que aparezcan bajo el bloque correcto.
+ *
+ * Ejemplo (repite en cada era si aplica, p. ej. tech lead en todas):
+ * {
+ *   firstName: 'Nombre',
+ *   lastName: 'Apellido',
+ *   role: 'Tech Lead de desarrollo',
+ *   roleGroup: 'techLeadDevelopment',
+ *   linkedinUrl: 'https://www.linkedin.com/in/...',
+ *   githubUrl: 'https://github.com/...',
+ * }
+ */
+const teaser: HeritageContributor[] = []
+
+const intermediate: HeritageContributor[] = []
+
+/** Sitio actual: varias cohorts; sigue en desarrollo — añade aquí a cada participante. */
+const current: HeritageContributor[] = []
+
+export const heritageContributorsByEra: Record<HeritageEraSlug, HeritageContributor[]> = {
+  teaser,
+  intermediate,
+  current,
+}
+
+export function getContributorsForEra(era: HeritageEraSlug): HeritageContributor[] {
+  return heritageContributorsByEra[era]
+}

--- a/src/data/heritage/eraConfig.ts
+++ b/src/data/heritage/eraConfig.ts
@@ -1,0 +1,17 @@
+import type { HeritageEraSlug } from '@/data/heritage/types'
+
+export const HERITAGE_ERA_SLUGS: HeritageEraSlug[] = ['teaser', 'intermediate', 'current']
+
+export function isHeritageEraSlug(value: string): value is HeritageEraSlug {
+  return HERITAGE_ERA_SLUGS.includes(value as HeritageEraSlug)
+}
+
+/**
+ * Enlace principal por etapa (abre en nueva pestaña si es https).
+ * La etapa actual no lleva botón: el usuario ya está en este sitio.
+ */
+export const heritageEraArchiveHref: Record<HeritageEraSlug, string | undefined> = {
+  teaser: 'https://teaser.shehub.es/',
+  intermediate: 'https://shehub-xvlf.vercel.app/',
+  current: undefined,
+}

--- a/src/data/heritage/groupContributors.ts
+++ b/src/data/heritage/groupContributors.ts
@@ -1,0 +1,19 @@
+import { HERITAGE_ROLE_GROUP_ORDER } from '@/data/heritage/roleGroupOrder'
+import type { HeritageContributor, HeritageRoleGroup } from '@/data/heritage/types'
+
+export function groupHeritageContributors(
+  people: HeritageContributor[]
+): { group: HeritageRoleGroup; people: HeritageContributor[] }[] {
+  const buckets = new Map<HeritageRoleGroup, HeritageContributor[]>()
+  for (const g of HERITAGE_ROLE_GROUP_ORDER) {
+    buckets.set(g, [])
+  }
+  for (const person of people) {
+    const key = buckets.has(person.roleGroup) ? person.roleGroup : 'other'
+    buckets.get(key)!.push(person)
+  }
+  return HERITAGE_ROLE_GROUP_ORDER.map((group) => ({
+    group,
+    people: buckets.get(group) ?? [],
+  })).filter((section) => section.people.length > 0)
+}

--- a/src/data/heritage/index.ts
+++ b/src/data/heritage/index.ts
@@ -1,0 +1,16 @@
+export {
+  getContributorsForEra,
+  heritageContributorsByEra,
+} from '@/data/heritage/contributors'
+export { groupHeritageContributors } from '@/data/heritage/groupContributors'
+export {
+  HERITAGE_ERA_SLUGS,
+  heritageEraArchiveHref,
+  isHeritageEraSlug,
+} from '@/data/heritage/eraConfig'
+export { HERITAGE_ROLE_GROUP_ORDER } from '@/data/heritage/roleGroupOrder'
+export type {
+  HeritageContributor,
+  HeritageEraSlug,
+  HeritageRoleGroup,
+} from '@/data/heritage/types'

--- a/src/data/heritage/roleGroupOrder.ts
+++ b/src/data/heritage/roleGroupOrder.ts
@@ -1,0 +1,14 @@
+import type { HeritageRoleGroup } from '@/data/heritage/types'
+
+export const HERITAGE_ROLE_GROUP_ORDER: HeritageRoleGroup[] = [
+  'cohortLead',
+  'techLeadDevelopment',
+  'productManager',
+  'projectManager',
+  'design',
+  'frontend',
+  'backend',
+  'data',
+  'qa',
+  'other',
+]

--- a/src/data/heritage/types.ts
+++ b/src/data/heritage/types.ts
@@ -1,0 +1,24 @@
+export type HeritageEraSlug = 'teaser' | 'intermediate' | 'current'
+
+/** Orden de secciones en la página de equipo (líderazgo primero, luego disciplinas). */
+export type HeritageRoleGroup =
+  | 'cohortLead'
+  | 'techLeadDevelopment'
+  | 'productManager'
+  | 'projectManager'
+  | 'design'
+  | 'frontend'
+  | 'backend'
+  | 'data'
+  | 'qa'
+  | 'other'
+
+export type HeritageContributor = {
+  firstName: string
+  lastName: string
+  /** Título visible (ej. «Product Manager», «Diseño UI»). */
+  role: string
+  roleGroup: HeritageRoleGroup
+  linkedinUrl?: string
+  githubUrl?: string
+}

--- a/src/lib/providers.tsx
+++ b/src/lib/providers.tsx
@@ -3,6 +3,7 @@
 import { LanguageProvider } from "@/providers/LanguageProvider";
 import { ReduxProvider } from "@/providers/ReduxProvider";
 import { ThemeProvider } from "@/providers/ThemeProvider";
+import { UserTabbingClass } from "@/providers/UserTabbingClass";
 import type { Language } from "@/translations";
 import { ReactNode } from "react";
 
@@ -17,6 +18,7 @@ export function AppProviders({
     <ReduxProvider>
       <LanguageProvider initialLanguage={initialLanguage}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <UserTabbingClass />
           {children}
         </ThemeProvider>
       </LanguageProvider>

--- a/src/providers/UserTabbingClass.tsx
+++ b/src/providers/UserTabbingClass.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Añade `user-is-tabbing` en <html> al usar Tab (u otras teclas de foco).
+ * Cualquier pointer la quita: el anillo/borde de “foco” solo con teclado.
+ */
+export function UserTabbingClass() {
+  useEffect(() => {
+    const root = document.documentElement
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        root.classList.add('user-is-tabbing')
+      }
+    }
+
+    const onPointerDown = () => {
+      root.classList.remove('user-is-tabbing')
+    }
+
+    const capture = true
+    const touchOpts: AddEventListenerOptions = { capture, passive: true }
+    window.addEventListener('keydown', onKeyDown, capture)
+    window.addEventListener('mousedown', onPointerDown, capture)
+    window.addEventListener('touchstart', onPointerDown, touchOpts)
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, capture)
+      window.removeEventListener('mousedown', onPointerDown, capture)
+      window.removeEventListener('touchstart', onPointerDown, touchOpts)
+    }
+  }, [])
+
+  return null
+}

--- a/src/sections/about/hero/Hero.tsx
+++ b/src/sections/about/hero/Hero.tsx
@@ -22,7 +22,7 @@ export default function AboutHero() {
       mainImage={HeroImage.src}
       alt="Women collaborating and innovating in tech, representing the SheHub community"
       buttons={[
-        { text: "Join a real project", variant: "primary-primary" },
+        { text: "Join a real project", variant: "primary-primary", href: "/join" },
       ]}
     />
   )

--- a/src/sections/collaborators/callToAction/CallToAction.tsx
+++ b/src/sections/collaborators/callToAction/CallToAction.tsx
@@ -5,7 +5,7 @@ export default function CollaboratorsCallToAction() {
     <CallToActionLayout
       title="Connect. Create. Break Barriers."
       buttonText="Join as a collaborator"
-      buttonHref="/auth"
+      buttonHref="/join"
       buttonVariant="secondary-primary"
     />
   );

--- a/src/sections/collaborators/whyCollaborator/WhyCollaborator.tsx
+++ b/src/sections/collaborators/whyCollaborator/WhyCollaborator.tsx
@@ -21,8 +21,8 @@ const features = [
     icon: IconMapPinHouse,
   },
   {
-    title: "Zero cost, global reach",
-    description: "Join for free and work with peers from around the world.",
+    title: "Global community",
+    description: "Connect and collaborate with peers from around the world.",
     icon: IconEarth,
   },
 ];

--- a/src/sections/heritage/HeritageContributorCard.tsx
+++ b/src/sections/heritage/HeritageContributorCard.tsx
@@ -1,0 +1,44 @@
+import IconLinkedIn from '@/components/icons/IconLinkedIn'
+import { Icon } from '@/components/ui/Icon'
+import type { HeritageContributor } from '@/data/heritage/types'
+import { Github } from 'lucide-react'
+
+type Props = {
+  person: HeritageContributor
+  linkedinAria: string
+  githubAria: string
+}
+
+export default function HeritageContributorCard({ person, linkedinAria, githubAria }: Props) {
+  const fullName = `${person.firstName} ${person.lastName}`
+  return (
+    <article className="rounded-2xl border border-black/10 bg-white p-5 shadow-[0_2px_8px_rgba(14,14,14,0.06)]">
+      <h3 className="font-primary text-lg font-bold text-black">{fullName}</h3>
+      <p className="mt-1 text-sm leading-relaxed text-gray-700 font-secondary">{person.role}</p>
+      <div className="mt-4 flex items-center gap-4">
+        {person.linkedinUrl ? (
+          <a
+            href={person.linkedinUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-purple-700 transition-opacity hover:opacity-80"
+            aria-label={`${linkedinAria} ${fullName}`}
+          >
+            <Icon icon={IconLinkedIn} size="md" />
+          </a>
+        ) : null}
+        {person.githubUrl ? (
+          <a
+            href={person.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-purple-700 transition-opacity hover:opacity-80"
+            aria-label={`${githubAria} ${fullName}`}
+          >
+            <Github className="h-[22px] w-[22px]" strokeWidth={1.75} aria-hidden />
+          </a>
+        ) : null}
+      </div>
+    </article>
+  )
+}

--- a/src/sections/heritage/HeritageEraTeamContent.tsx
+++ b/src/sections/heritage/HeritageEraTeamContent.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import {
+  getContributorsForEra,
+  groupHeritageContributors,
+  type HeritageEraSlug,
+  type HeritageRoleGroup,
+} from '@/data/heritage'
+import { useTranslation } from '@/hooks/useTranslation'
+import HeritageContributorCard from '@/sections/heritage/HeritageContributorCard'
+import SectionWrapper from '@/sections/shared/sectionWrapper/SectionWrapper'
+import Link from 'next/link'
+
+const TITLE_KEYS: Record<HeritageEraSlug, string> = {
+  teaser: 'heritage.team.title.teaser',
+  intermediate: 'heritage.team.title.intermediate',
+  current: 'heritage.team.title.current',
+}
+
+function roleGroupTranslationKey(group: HeritageRoleGroup): string {
+  return `heritage.roleGroup.${group}`
+}
+
+type Props = {
+  era: HeritageEraSlug
+}
+
+export default function HeritageEraTeamContent({ era }: Props) {
+  const { t } = useTranslation()
+  const people = getContributorsForEra(era)
+  const sections = groupHeritageContributors(people)
+
+  return (
+    <main className="bg-background text-foreground">
+      <SectionWrapper className="bg-background-footer py-10 md:py-14">
+        <div className="max-w-3xl">
+          <Link
+            href="/heritage"
+            className="text-sm font-semibold text-purple-700 underline decoration-purple-700/50 underline-offset-4 hover:text-purple-600"
+          >
+            {t('heritage.team.backLink')}
+          </Link>
+          <h1 className="mt-6 font-primary text-3xl font-bold leading-tight tracking-tight text-black md:text-4xl lg:text-5xl">
+            {t(TITLE_KEYS[era])}
+          </h1>
+          <p className="mt-5 text-base leading-relaxed text-gray-800 font-secondary md:text-lg">
+            {t('heritage.team.intro')}
+          </p>
+        </div>
+      </SectionWrapper>
+
+      <SectionWrapper className="py-12 md:py-16">
+        <div className="mx-auto max-w-5xl">
+          {sections.length === 0 ? (
+            <p className="text-base italic leading-relaxed text-gray-600 font-secondary">
+              {t('heritage.team.emptyEra')}
+            </p>
+          ) : (
+            <div className="space-y-14">
+              {sections.map(({ group, people: groupPeople }) => (
+                <section key={group} aria-labelledby={`heritage-group-${group}`}>
+                  <h2
+                    id={`heritage-group-${group}`}
+                    className="font-primary text-2xl font-bold text-black md:text-3xl"
+                  >
+                    {t(roleGroupTranslationKey(group))}
+                  </h2>
+                  <ul className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {groupPeople.map((person, i) => (
+                      <li key={`${person.firstName}-${person.lastName}-${i}`}>
+                        <HeritageContributorCard
+                          person={person}
+                          linkedinAria={t('heritage.contributors.linkedinAria')}
+                          githubAria={t('heritage.contributors.githubAria')}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </SectionWrapper>
+    </main>
+  )
+}

--- a/src/sections/heritage/HeritagePageContent.tsx
+++ b/src/sections/heritage/HeritagePageContent.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { heritageEraArchiveHref, type HeritageEraSlug } from '@/data/heritage'
+import { useTranslation } from '@/hooks/useTranslation'
+import SectionWrapper from '@/sections/shared/sectionWrapper/SectionWrapper'
+import Link from 'next/link'
+
+const ERA_SLUGS: HeritageEraSlug[] = ['teaser', 'intermediate', 'current']
+
+const archiveCtaClassName =
+  'inline-flex w-full items-center justify-center rounded-full bg-gradient-to-r from-[#f76702] via-[#f83c85] to-[#7858ff] px-6 py-3 font-secondary text-[length:var(--text-size-400)] !text-[var(--color-button-primary-primary-text)] shadow-sm transition-opacity hover:opacity-90 sm:w-auto min-h-[44px] text-center no-underline'
+
+const teamCtaClassName =
+  'inline-flex w-full items-center justify-center rounded-full border border-[var(--color-button-secondary-primary-border)] bg-[var(--color-button-secondary-primary-bg-default)] px-6 py-3 font-secondary text-[length:var(--text-size-400)] transition-colors hover:bg-[var(--color-button-secondary-primary-bg-hover)] sm:w-auto min-h-[44px] text-center no-underline !text-black hover:!text-black'
+
+function HeritageArchiveCta({ href, children }: { href: string; children: React.ReactNode }) {
+  if (href.startsWith('http://') || href.startsWith('https://')) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={archiveCtaClassName}>
+        {children}
+      </a>
+    )
+  }
+  return (
+    <Link href={href} className={archiveCtaClassName}>
+      {children}
+    </Link>
+  )
+}
+
+export default function HeritagePageContent() {
+  const { t } = useTranslation()
+
+  const timeline = ERA_SLUGS.map((slug) => ({
+    slug,
+    label: t(`heritage.timeline.${slug}.label`),
+    title: t(`heritage.timeline.${slug}.title`),
+    body: t(`heritage.timeline.${slug}.body`),
+    ctaArchive: t(`heritage.timeline.${slug}.ctaArchive`),
+    archiveHref: heritageEraArchiveHref[slug],
+  }))
+
+  return (
+    <main className="bg-background text-foreground">
+      <SectionWrapper className="bg-background-footer py-14 md:py-20">
+        <div className="max-w-3xl">
+          <p className="text-accent text-base font-semibold tracking-wide md:text-lg">
+            {t('heritage.hero.eyebrow')}
+          </p>
+          <h1 className="mt-4 font-primary text-4xl font-bold leading-tight tracking-tight text-black md:text-5xl lg:text-6xl">
+            {t('heritage.hero.titleBefore')}
+            <span
+              className="bg-clip-text text-transparent"
+              style={{ backgroundImage: 'var(--color-gradient-brand)' }}
+            >
+              {t('heritage.hero.titleHighlight')}
+            </span>
+          </h1>
+          <p className="mt-8 text-lg leading-relaxed text-gray-800 font-secondary md:text-xl">
+            {t('heritage.hero.intro')}
+          </p>
+        </div>
+      </SectionWrapper>
+
+      <SectionWrapper className="py-16 md:py-20">
+        <div className="mx-auto grid max-w-6xl gap-8 md:grid-cols-3">
+          {timeline.map((item) => (
+            <article
+              key={item.slug}
+              className="flex flex-col rounded-2xl border border-black/10 bg-white p-6 shadow-[0_2px_8px_rgba(14,14,14,0.06)] md:p-8"
+            >
+              <span
+                className="mb-4 inline-flex w-fit rounded-full px-3 py-1 text-xs font-bold tracking-wide text-white"
+                style={{ backgroundImage: 'var(--color-gradient-brand)' }}
+              >
+                {item.label}
+              </span>
+              <h2 className="font-primary text-xl font-bold text-black md:text-2xl">{item.title}</h2>
+              <p className="mt-3 flex-1 text-sm leading-relaxed text-gray-700 font-secondary md:text-base">
+                {item.body}
+              </p>
+
+              <div className="mt-8 flex flex-col gap-3">
+                {item.archiveHref ? (
+                  <HeritageArchiveCta href={item.archiveHref}>{item.ctaArchive}</HeritageArchiveCta>
+                ) : null}
+                <Link href={`/heritage/${item.slug}`} className={teamCtaClassName}>
+                  {t('heritage.timeline.ctaTeam')}
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
+      </SectionWrapper>
+    </main>
+  )
+}

--- a/src/sections/home/callToAction/CallToAction.tsx
+++ b/src/sections/home/callToAction/CallToAction.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import CallToActionLayout from "@/sections/shared/callToAction/CallToActionLayout"
-import { useTranslation } from "@/hooks/useTranslation"
+import { useTranslation } from "@/hooks/useTranslation";
+import CallToActionLayout from "@/sections/shared/callToAction/CallToActionLayout";
 
 export const CallToAction = () => {
   const { t } = useTranslation();
@@ -9,7 +9,7 @@ export const CallToAction = () => {
     <CallToActionLayout
       title={t('home.cta.title')}
       buttonText={t('home.cta.button')}
-      buttonHref="/auth"
+      buttonHref="/join"
       buttonVariant="secondary-primary"
     />
   )

--- a/src/sections/home/frequentlyAskedQuestions/components/ContactSection.tsx
+++ b/src/sections/home/frequentlyAskedQuestions/components/ContactSection.tsx
@@ -1,8 +1,22 @@
 "use client";
 
-import Button from "@/components/ui/Button"
-import Link from "next/link"
-import { useTranslation } from "@/hooks/useTranslation"
+import { CopyEmailTrigger } from "@/components/ui/CopyEmailTrigger";
+import { useTranslation } from "@/hooks/useTranslation";
+import { cn } from "@/lib/utils";
+
+const faqContactTriggerClassName = cn(
+  "btn",
+  "btn-secondary-primary",
+  "inline-flex items-center justify-center font-secondary transition-all duration-200 cursor-pointer",
+  "w-full lg:w-auto",
+  "min-h-[44px] min-w-[44px]",
+  "bg-[var(--color-button-secondary-primary-bg-default)] text-[var(--color-button-secondary-primary-text)] border border-[var(--color-button-secondary-primary-border)]",
+  "hover:bg-[var(--color-button-secondary-primary-bg-hover)] hover:!text-[var(--color-button-secondary-primary-text-hover)]",
+  "h-10 px-6 py-3 text-[var(--text-size-400)]",
+  "rounded-full",
+  "hover:!text-black",
+  "w-[234px]"
+);
 
 const ContactSection = () => {
   const { t } = useTranslation();
@@ -35,16 +49,9 @@ const ContactSection = () => {
       >
         {t('home.faq.contactText')}
       </p>
-      <Link href="/contact">
-        <Button
-          variant="secondary-primary"
-          size="sm"
-          shape="rounded"
-          className="w-[234px]"
-        >
-          {t('home.faq.contactCta')}
-        </Button>
-      </Link>
+      <CopyEmailTrigger className={faqContactTriggerClassName}>
+        {t("home.faq.contactCta")}
+      </CopyEmailTrigger>
 
     </div>
   )

--- a/src/sections/home/hero/Hero.tsx
+++ b/src/sections/home/hero/Hero.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import HeroLayout from "@/sections/shared/heroLayout/HeroLayout";
+import { useTranslation } from "@/hooks/useTranslation";
 import ImageSection from "@/sections/home/hero/components/ImageSection";
 import HeroText from "@/sections/home/hero/components/TypewriterAnimation";
-import { useTranslation } from "@/hooks/useTranslation";
+import HeroLayout from "@/sections/shared/heroLayout/HeroLayout";
 
 export default function Hero() {
   const { t } = useTranslation();
@@ -33,7 +33,7 @@ export default function Hero() {
       }
       paragraph={t("home.hero.paragraph")}
       buttons={[
-        { text: t("home.hero.ctaProject"), variant: "primary-primary", href: "/auth" },
+        { text: t("home.hero.ctaProject"), variant: "primary-primary", href: "/join" },
         { text: t("home.hero.ctaMentor"), variant: "secondary-primary", href: "/mentors" },
       ]}
       imageComponent={

--- a/src/sections/home/hero/components/TextSection.tsx
+++ b/src/sections/home/hero/components/TextSection.tsx
@@ -84,7 +84,7 @@ const TextSection = () => {
           gap-[16px]
         "
       >
-        <Link href="/auth">
+        <Link href="/join">
           <Button
             variant="primary-primary"
             size="sm"

--- a/src/sections/home/howSheHubWorks/HowSheHubWorks.tsx
+++ b/src/sections/home/howSheHubWorks/HowSheHubWorks.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import Button from "@/components/ui/Button";
-import SectionWrapper from "@/sections/shared/sectionWrapper/SectionWrapper";
+import IconCalendarCheck from "@/components/icons/IconCalendarCheck";
 import IconFilePen from "@/components/icons/IconFilePen";
 import IconHeartHandshake from "@/components/icons/IconHeartHandshake";
 import IconUserPlus from "@/components/icons/IconUserPlus";
-import IconCalendarCheck from "@/components/icons/IconCalendarCheck";
+import Button from "@/components/ui/Button";
 import { useTranslation } from "@/hooks/useTranslation";
+import SectionWrapper from "@/sections/shared/sectionWrapper/SectionWrapper";
 import Link from "next/link";
 
 const STEP_ICONS = [IconFilePen, IconHeartHandshake, IconUserPlus, IconCalendarCheck];
@@ -44,7 +44,7 @@ export default function HowSheHubWorks() {
       </div>
 
       <div className="mt-16 flex justify-center">
-        <Link href="/auth">
+        <Link href="/join">
           <Button
             variant="primary-primary"
             size="sm"

--- a/src/sections/mentors/callToAction/CallToAction.tsx
+++ b/src/sections/mentors/callToAction/CallToAction.tsx
@@ -5,7 +5,7 @@ export default function MentorsCallToAction() {
     <CallToActionLayout
       title="Ready to support and grow?"
       buttonText="Join as a mentor"
-      buttonHref="/auth"
+      buttonHref="/join"
       buttonVariant="secondary-primary"
     />
   );

--- a/src/sections/mentors/hero/Hero.tsx
+++ b/src/sections/mentors/hero/Hero.tsx
@@ -21,7 +21,7 @@ export default function MentorsHero() {
       mainImage={HeroImage.src}
       alt="SheHub mentors collaborating"
       buttons={[
-        { text: "Become a mentor", variant: "primary-primary", href: "/auth" },
+        { text: "Become a mentor", variant: "primary-primary", href: "/join" },
       ]}
     />
   )

--- a/src/sections/mentors/whyMentor/WhyMentor.tsx
+++ b/src/sections/mentors/whyMentor/WhyMentor.tsx
@@ -43,7 +43,7 @@ export default function WhyMentor() {
       button={{
         text: "Become a mentor",
         variant: "secondary-primary",
-        href: "/auth",
+        href: "/join",
       }}
       backgroundClassName="bg-purple-100"
       layout="left-aligned"

--- a/src/sections/partners/callToAction/CallToAction.tsx
+++ b/src/sections/partners/callToAction/CallToAction.tsx
@@ -5,7 +5,7 @@ export default function PartnersCallToAction() {
     <CallToActionLayout
       title="Want to collaborate?"
       buttonText="Join as a partner"
-      buttonHref="/auth"
+      buttonHref="/join"
       buttonVariant="secondary-primary"
     />
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -303,6 +303,9 @@
 
   --input-border-default: var(--color-neutral-300);
   --input-border-hover: var(--color-neutral-400);
+  /* Figma: hover campo texto — borde 2px #6230F7, fondo #FEFEFE */
+  --input-border-hover-figma: #6230f7;
+  --input-bg-hover-figma: #fefefe;
   --input-border-focus: var(--color-primary);
   --input-border-error: var(--color-error);
   --input-border-success: var(--color-success);
@@ -318,6 +321,22 @@
   --input-ring-focus: rgba(120, 88, 255, 0.1);
   --input-ring-error: rgba(219, 51, 39, 0.1);
   --input-ring-success: rgba(13, 135, 94, 0.1);
+
+  /* Figma: foco teclado — trazo exterior 5px #6230F7, separación 2px blanca, campo 2px #D1D1D1, fondo #FEFEFE */
+  --input-focus-stroke-figma: #6230f7;
+  --input-focus-gap-figma: #ffffff;
+  --input-border-field-figma: #d1d1d1;
+  --input-bg-field-figma: #fefefe;
+  --input-focus-gap-width: 2px;
+  --input-focus-stroke-width: 5px;
+
+  /* Figma: dropdown ghost — trazo exterior 3px #6230F7, gap 2px blanco, radio interior 12px / marco 14px */
+  --dropdown-focus-stroke-width: 3px;
+  --dropdown-focus-gap-width: 2px;
+  --dropdown-focus-radius: 12px;
+  --dropdown-focus-outer-radius: 14px;
+  --dropdown-menu-bg-figma: #fefefe;
+  --dropdown-item-highlight-bg-figma: #e9e8ff;
 
   /* Input Dimensions */
   --input-border-radius: 12px;
@@ -544,18 +563,33 @@ html.scrollbar-visible *::-webkit-scrollbar-thumb,
   }
 }
 
-:focus-visible {
+/*
+ * Foco visible solo con teclado: <html class="user-is-tabbing"> (UserTabbingClass).
+ * Con ratón no debe aparecer anillo al hacer clic ni al hover.
+ */
+html:not(.user-is-tabbing) *:focus {
+  outline: none !important;
+}
+
+html.user-is-tabbing *:focus {
   outline: 0.25rem solid var(--color-purple-600);
   outline-offset: 0.125rem;
   position: relative;
 }
 
-/* Checkbox: focus ring on the box only, not the whole label; hidden input without outline */
-.checkbox-input-sr-only:focus-visible {
-  outline: none;
+/* Tailwind ring = box-shadow: quitar con ratón en botones */
+html:not(.user-is-tabbing) button:focus {
+  --tw-ring-offset-shadow: 0 0 #0000 !important;
+  --tw-ring-shadow: 0 0 #0000 !important;
+  box-shadow: none !important;
 }
 
-.checkbox-label:focus-within .checkbox-box {
+/* Checkbox: sin outline en el input oculto; caja marcada solo con teclado */
+.checkbox-input-sr-only:focus {
+  outline: none !important;
+}
+
+html.user-is-tabbing .checkbox-label:has(input:focus) .checkbox-box {
   outline: 0.25rem solid var(--color-purple-600);
   outline-offset: 0;
 }
@@ -589,27 +623,46 @@ html.scrollbar-visible *::-webkit-scrollbar-thumb,
              var(--input-padding-vertical) var(--input-padding-horizontal-left);
     font-size: var(--input-font-size);
     color: var(--input-text-default);
-    background-color: var(--input-bg-default);
-    border: var(--input-border-width-default) solid var(--input-border-default);
+    background-color: var(--input-bg-field-figma);
+    border: 2px solid var(--input-border-field-figma);
     border-radius: var(--input-border-radius);
-    transition: all 150ms ease-in-out;
+    transition: border-color 150ms ease-in-out, background-color 150ms ease-in-out,
+      box-shadow 150ms ease-in-out;
   }
 
   .input-base::placeholder {
     color: var(--input-text-placeholder);
   }
 
-  /* Hover State */
+  /* Hover State (Figma: 2px #6230F7, fondo #FEFEFE) */
   .input-base:hover:not(:disabled) {
-    border-color: var(--input-border-hover);
+    border-color: var(--input-border-hover-figma);
+    background-color: var(--input-bg-hover-figma);
   }
 
-  /* Focus State */
+  /* Foco con ratón: mismo borde que reposo; con teclado (user-is-tabbing): borde de foco */
   .input-base:focus {
-    outline: none;
-    border-width: var(--input-border-width-focus);
-    border-color: var(--input-border-focus);
+    outline: none !important;
     box-shadow: none;
+  }
+
+  html:not(.user-is-tabbing) .input-base:focus {
+    border-width: 2px;
+    border-color: var(--input-border-field-figma);
+    background-color: var(--input-bg-field-figma);
+  }
+
+  /* Figma focus: anillo morado + gap blanco (box-shadow); borde interior 2px gris (no aplica al select: .shehub-dropdown-trigger) */
+  html.user-is-tabbing
+    .input-base:focus:not(.input-error):not(.input-success):not(.shehub-dropdown-trigger) {
+    outline: none !important;
+    border-width: 2px;
+    border-color: var(--input-border-field-figma);
+    background-color: var(--input-bg-field-figma);
+    box-shadow:
+      0 0 0 var(--input-focus-gap-width) var(--input-focus-gap-figma),
+      0 0 0 calc(var(--input-focus-gap-width) + var(--input-focus-stroke-width))
+        var(--input-focus-stroke-figma);
   }
 
   /* Error State */
@@ -618,8 +671,48 @@ html.scrollbar-visible *::-webkit-scrollbar-thumb,
     border-color: var(--input-border-error);
   }
 
-  .input-error:focus {
-    box-shadow: 0 0 0 var(--input-ring-width) var(--input-ring-error);
+  html:not(.user-is-tabbing) .input-error:focus {
+    box-shadow: none !important;
+  }
+
+  html.user-is-tabbing .input-error:focus:not(.shehub-dropdown-trigger) {
+    outline: none !important;
+    border-width: 2px;
+    border-color: var(--input-border-error);
+    background-color: var(--input-bg-field-figma);
+    box-shadow:
+      0 0 0 var(--input-focus-gap-width) var(--input-focus-gap-figma),
+      0 0 0 calc(var(--input-focus-gap-width) + var(--input-focus-stroke-width))
+        var(--input-border-error);
+  }
+
+  /* Dropdown (input-base + shehub-dropdown-trigger): trazo 3px Figma */
+  html:not(.user-is-tabbing) .shehub-dropdown-trigger:focus {
+    box-shadow: none !important;
+  }
+
+  html.user-is-tabbing .shehub-dropdown-trigger:focus:not(.input-error) {
+    outline: none !important;
+    border-radius: var(--dropdown-focus-radius);
+    border-width: 2px;
+    border-color: var(--input-border-field-figma);
+    background-color: var(--input-bg-field-figma);
+    box-shadow:
+      0 0 0 var(--dropdown-focus-gap-width) var(--input-focus-gap-figma),
+      0 0 0 calc(var(--dropdown-focus-gap-width) + var(--dropdown-focus-stroke-width))
+        var(--input-focus-stroke-figma);
+  }
+
+  html.user-is-tabbing .shehub-dropdown-trigger.input-error:focus {
+    outline: none !important;
+    border-radius: var(--dropdown-focus-radius);
+    border-width: 2px;
+    border-color: var(--input-border-error);
+    background-color: var(--input-bg-field-figma);
+    box-shadow:
+      0 0 0 var(--dropdown-focus-gap-width) var(--input-focus-gap-figma),
+      0 0 0 calc(var(--dropdown-focus-gap-width) + var(--dropdown-focus-stroke-width))
+        var(--input-border-error);
   }
 
   /* Success State */
@@ -628,8 +721,19 @@ html.scrollbar-visible *::-webkit-scrollbar-thumb,
     border-color: var(--input-border-success);
   }
 
-  .input-success:focus {
-    box-shadow: 0 0 0 var(--input-ring-width) var(--input-ring-success);
+  html:not(.user-is-tabbing) .input-success:focus {
+    box-shadow: none !important;
+  }
+
+  html.user-is-tabbing .input-success:focus {
+    outline: none !important;
+    border-width: 2px;
+    border-color: var(--input-border-success);
+    background-color: var(--input-bg-field-figma);
+    box-shadow:
+      0 0 0 var(--input-focus-gap-width) var(--input-focus-gap-figma),
+      0 0 0 calc(var(--input-focus-gap-width) + var(--input-focus-stroke-width))
+        var(--input-border-success);
   }
 
   /* Disabled State */
@@ -661,6 +765,56 @@ html.scrollbar-visible *::-webkit-scrollbar-thumb,
 
   .input-helper.success {
     color: var(--input-border-success);
+  }
+
+  /* Contact / Input.tsx: el <input> interno nunca muestra outline (el marco es el wrapper) */
+  .sh-input-wrap input:focus {
+    outline: none !important;
+  }
+
+  /* Contact / Input.tsx: borde fuerte solo con teclado */
+  html:not(.user-is-tabbing) .sh-input-wrap:has(input:focus) {
+    box-shadow: none !important;
+  }
+
+  html:not(.user-is-tabbing) .sh-input-wrap--default:has(input:focus) {
+    border-color: rgb(212 212 212);
+  }
+
+  /* Input.tsx: hover Figma (borde #6230F7, fondo #FEFEFE) — no si está enfocado o deshabilitado */
+  .sh-input-wrap--default:hover:not(:has(input:focus)):not(:has(input:disabled)) {
+    border-color: var(--input-border-hover-figma);
+    background-color: var(--input-bg-hover-figma);
+  }
+
+  html.user-is-tabbing .sh-input-wrap--default:has(input:focus) {
+    border-width: 2px;
+    border-color: var(--input-border-field-figma);
+    background-color: var(--input-bg-field-figma);
+    box-shadow:
+      0 0 0 var(--input-focus-gap-width) var(--input-focus-gap-figma),
+      0 0 0 calc(var(--input-focus-gap-width) + var(--input-focus-stroke-width))
+        var(--input-focus-stroke-figma);
+  }
+
+  html.user-is-tabbing .sh-input-wrap--error:has(input:focus) {
+    border-width: 2px;
+    border-color: var(--input-border-error);
+    background-color: var(--input-bg-field-figma);
+    box-shadow:
+      0 0 0 var(--input-focus-gap-width) var(--input-focus-gap-figma),
+      0 0 0 calc(var(--input-focus-gap-width) + var(--input-focus-stroke-width))
+        var(--input-border-error);
+  }
+
+  html.user-is-tabbing .sh-input-wrap--success:has(input:focus) {
+    border-width: 2px;
+    border-color: var(--input-border-success);
+    background-color: var(--input-bg-field-figma);
+    box-shadow:
+      0 0 0 var(--input-focus-gap-width) var(--input-focus-gap-figma),
+      0 0 0 calc(var(--input-focus-gap-width) + var(--input-focus-stroke-width))
+        var(--input-border-success);
   }
 }
 

--- a/src/translations/heritage/heritageTranslations.ts
+++ b/src/translations/heritage/heritageTranslations.ts
@@ -1,0 +1,194 @@
+import type { TranslationObject } from '@/translations/types'
+
+export const heritageTranslations: TranslationObject = {
+  'heritage.navLink': {
+    es: 'Recorrido',
+    en: 'Our journey',
+    ca: 'Recorregut',
+  },
+  'heritage.metaTitle': {
+    es: 'Recorrido web',
+    en: 'Website journey',
+    ca: 'Recorregut web',
+  },
+  'heritage.metaDescription': {
+    es: 'Cómo ha evolucionado la presencia online de SheHub y quién participó en cada etapa: teaser, sitio intermedio y web actual con design system.',
+    en: 'How SheHub’s online presence evolved and who shaped each stage: teaser, intermediate site, and today’s design-system web.',
+    ca: 'Com ha evolucionat la presència online de SheHub i qui va participar en cada etapa: teaser, lloc intermedi i web actual amb design system.',
+  },
+  'heritage.hero.eyebrow': {
+    es: 'Historia del sitio',
+    en: 'Site history',
+    ca: 'Història del lloc',
+  },
+  'heritage.hero.titleBefore': {
+    es: 'Tres etapas, ',
+    en: 'Three stages, ',
+    ca: 'Tres etapes, ',
+  },
+  'heritage.hero.titleHighlight': {
+    es: 'una comunidad',
+    en: 'one community',
+    ca: 'una comunitat',
+  },
+  'heritage.hero.intro': {
+    es: 'SheHub no nació con esta web. Hubo una teaser inicial, un sitio que nos acompañó un año y la versión actual, con design system y varias cohorts aún en marcha. En cada fase participaron perfiles de todo el producto digital: product y project management, diseño, desarrollo front y back, datos, calidad y liderazgo técnico. En las dos primeras etapas puedes abrir la web tal y como era; en la actual estás ya aquí, y en todas puedes ver quién lo hizo posible.',
+    en: 'SheHub did not start with this site. There was an early teaser, a site we used for a year, and today’s version—with a design system and several cohorts still in motion. Each phase involved the full range of digital product roles: product and project management, design, front- and back-end development, data, QA, and technical leadership. For the first two stages you can open the site as it was; for the current one you are already here—and on every stage you can see who made it happen.',
+    ca: 'SheHub no va néixer amb aquest web. Hi va haver una teaser inicial, un lloc que ens va acompanyar un any i la versió actual, amb design system i diverses cohorts encara en marxa. En cada fase hi van participar perfils de tot el producte digital: producte i project management, disseny, desenvolupament front i back, dades, qualitat i lideratge tècnic. En les dues primeres etapes pots obrir el web tal com era; en l’actual ja hi ets, i a totes pots veure qui ho va fer possible.',
+  },
+  'heritage.timeline.teaser.label': {
+    es: '1 · Teaser',
+    en: '1 · Teaser',
+    ca: '1 · Teaser',
+  },
+  'heritage.timeline.teaser.title': {
+    es: 'Los inicios en la web',
+    en: 'The early web presence',
+    ca: 'Els inicis al web',
+  },
+  'heritage.timeline.teaser.body': {
+    es: 'La primera presencia online fue una página teaser: poco contenido, mucha intención. Sirvió para presentar la idea de SheHub y generar expectativa antes de tener producto ni flujos complejos.',
+    en: 'Our first online presence was a teaser page: little content, strong intent. It introduced the SheHub idea and built anticipation before we had a full product or complex flows.',
+    ca: 'La primera presència online va ser una pàgina teaser: poc contingut, molta intenció. Va servir per presentar la idea de SheHub i generar expectativa abans de tenir producte ni fluxos complexos.',
+  },
+  'heritage.timeline.teaser.ctaArchive': {
+    es: 'Echar un vistazo a la teaser',
+    en: 'Take a peek at the teaser',
+    ca: 'Donar un cop d’ull a la teaser',
+  },
+  'heritage.timeline.intermediate.label': {
+    es: '2 · Sitio intermedio',
+    en: '2 · Intermediate site',
+    ca: '2 · Lloc intermedi',
+  },
+  'heritage.timeline.intermediate.title': {
+    es: 'Un año de aprendizaje',
+    en: 'A year of learning',
+    ca: 'Un any d’aprenentatge',
+  },
+  'heritage.timeline.intermediate.body': {
+    es: 'La segunda versión fue el sitio que usamos durante aproximadamente un año: más páginas, mensaje claro y la primera experiencia completa para mentoras, colaboradoras y aliadas.',
+    en: 'The second version was the site we used for about a year: more pages, clearer messaging, and the first full experience for mentors, collaborators, and partners.',
+    ca: 'La segona versió va ser el lloc que vam utilitzar durant aproximadament un any: més pàgines, missatge clar i la primera experiència completa per a mentores, col·laboradores i aliades.',
+  },
+  'heritage.timeline.intermediate.ctaArchive': {
+    es: 'Recordar esa versión',
+    en: 'Revisit that version',
+    ca: 'Recordar aquella versió',
+  },
+  'heritage.timeline.current.label': {
+    es: '3 · Hoy',
+    en: '3 · Today',
+    ca: '3 · Avui',
+  },
+  'heritage.timeline.current.title': {
+    es: 'Design system y sitio actual',
+    en: 'Design system and current site',
+    ca: 'Design system i lloc actual',
+  },
+  'heritage.timeline.current.body': {
+    es: 'La web actual nace con un design system y varias cohorts de trabajo; sigue evolucionando. Aquí reconocemos también a quienes están construyendo esta etapa.',
+    en: 'Today’s site is built with a design system and several work cohorts; it keeps evolving. Here we also recognise the people building this stage.',
+    ca: 'El web actual neix amb un design system i diverses cohorts de treball; continua evolucionant. Aquí reconeixem també qui està construint aquesta etapa.',
+  },
+  'heritage.timeline.current.ctaArchive': {
+    es: 'Ir al sitio de hoy',
+    en: 'Go to today’s site',
+    ca: 'Anar al lloc d’avui',
+  },
+  'heritage.timeline.ctaTeam': {
+    es: 'Quién lo hizo posible',
+    en: 'Who made it happen',
+    ca: 'Qui ho va fer possible',
+  },
+  'heritage.team.backLink': {
+    es: '← Volver al recorrido',
+    en: '← Back to the journey',
+    ca: '← Tornar al recorregut',
+  },
+  'heritage.team.intro': {
+    es: 'Listado por rol: liderazgo de cohort, producto, proyecto, diseño, desarrollo y más. Los enlaces llevan a perfiles públicos cuando existen.',
+    en: 'Listed by role: cohort leadership, product, project, design, development, and more. Links go to public profiles when available.',
+    ca: 'Llistat per rol: lideratge de cohort, producte, projecte, disseny, desenvolupament i més. Els enllaços van a perfils públics quan n’hi ha.',
+  },
+  'heritage.team.title.teaser': {
+    es: 'Equipo · Teaser inicial',
+    en: 'Team · Initial teaser',
+    ca: 'Equip · Teaser inicial',
+  },
+  'heritage.team.title.intermediate': {
+    es: 'Equipo · Sitio intermedio',
+    en: 'Team · Intermediate site',
+    ca: 'Equip · Lloc intermedi',
+  },
+  'heritage.team.title.current': {
+    es: 'Equipo · Sitio actual (en desarrollo)',
+    en: 'Team · Current site (in development)',
+    ca: 'Equip · Lloc actual (en desenvolupament)',
+  },
+  'heritage.team.emptyEra': {
+    es: 'Aún no hay personas listadas en esta etapa. Si participaste, escríbenos a info@shehub.es.',
+    en: 'No one is listed for this stage yet. If you contributed, write to us at info@shehub.es.',
+    ca: 'Encara no hi ha persones llistades en aquesta etapa. Si hi vas participar, escriu-nos a info@shehub.es.',
+  },
+  'heritage.roleGroup.cohortLead': {
+    es: 'Liderazgo de cohort',
+    en: 'Cohort leads',
+    ca: 'Lideratge de cohort',
+  },
+  'heritage.roleGroup.techLeadDevelopment': {
+    es: 'Tech lead de desarrollo',
+    en: 'Development tech lead',
+    ca: 'Tech lead de desenvolupament',
+  },
+  'heritage.roleGroup.productManager': {
+    es: 'Product management',
+    en: 'Product management',
+    ca: 'Product management',
+  },
+  'heritage.roleGroup.projectManager': {
+    es: 'Project management',
+    en: 'Project management',
+    ca: 'Project management',
+  },
+  'heritage.roleGroup.design': {
+    es: 'Diseño',
+    en: 'Design',
+    ca: 'Disseny',
+  },
+  'heritage.roleGroup.frontend': {
+    es: 'Desarrollo frontend',
+    en: 'Frontend development',
+    ca: 'Desenvolupament frontend',
+  },
+  'heritage.roleGroup.backend': {
+    es: 'Desarrollo backend',
+    en: 'Backend development',
+    ca: 'Desenvolupament backend',
+  },
+  'heritage.roleGroup.data': {
+    es: 'Datos y analítica',
+    en: 'Data & analytics',
+    ca: 'Dades i analítica',
+  },
+  'heritage.roleGroup.qa': {
+    es: 'Calidad y testing',
+    en: 'QA & testing',
+    ca: 'Qualitat i testing',
+  },
+  'heritage.roleGroup.other': {
+    es: 'Otras colaboradoras',
+    en: 'Other contributors',
+    ca: 'Altres col·laboradores',
+  },
+  'heritage.contributors.linkedinAria': {
+    es: 'Perfil de LinkedIn de',
+    en: 'LinkedIn profile of',
+    ca: 'Perfil de LinkedIn de',
+  },
+  'heritage.contributors.githubAria': {
+    es: 'Perfil de GitHub de',
+    en: 'GitHub profile of',
+    ca: 'Perfil de GitHub de',
+  },
+}

--- a/src/translations/home/homeTranslations.ts
+++ b/src/translations/home/homeTranslations.ts
@@ -115,14 +115,14 @@ export const homeTranslations: TranslationObject = {
     ca: "Cada projecte és 100% remot i a temps parcial, pensat per compaginar amb feina, estudis o vida personal.",
   },
   'home.valueProp.free.title': {
-    es: 'Gratis',
-    en: 'Free',
-    ca: 'Gratuït',
+    es: 'Experiencia completa',
+    en: 'The full experience',
+    ca: 'Experiència completa',
   },
   'home.valueProp.free.desc': {
-    es: 'Las colaboradoras no pagan por formar parte de SheHub. Mentoría, experiencia real y comunidad — todo sin coste.',
-    en: "Contributors never pay to be part of SheHub. Access mentorship, real-world experience, and a supportive tech community — all at zero cost.",
-    ca: "Les col·laboradores no paguen per formar part de SheHub. Mentorització, experiència real i comunitat — tot sense cost.",
+    es: 'Mentoría, proyecto real y comunidad en un mismo recorrido, para ganar confianza, habilidades y un portfolio alineado con el mercado.',
+    en: 'Guided mentorship, a real project, and community in one pathway—so you build confidence, skills, and a market-ready portfolio.',
+    ca: "Mentorització, projecte real i comunitat en un mateix recorregut, per guanyar confiança, habilitats i un portafoli alineat amb el mercat.",
   },
   'home.valueProp.international.title': {
     es: 'Entorno internacional',
@@ -437,14 +437,14 @@ export const homeTranslations: TranslationObject = {
     ca: "Col·laboradores: Dones que pivoten cap a tech, normalment de bootcamps o autodidactes, amb habilitats tècniques o de disseny per contribuir en un equip de producte real. Mentores: Dones en tech que volen retornar, donar suport a altres o créixer en lideratge mentre es preparen per al proper pas (ex. management, team lead, estratègia).",
   },
   'home.faq.q3': {
-    es: '¿Es gratis?',
-    en: 'Is it free?',
-    ca: 'És gratuït?',
+    es: '¿Qué incluye participar en SheHub?',
+    en: 'What does taking part in SheHub include?',
+    ca: 'Què inclou participar a SheHub?',
   },
   'home.faq.a3': {
-    es: 'Sí — SheHub es 100% gratis para colaboradoras y mentoras. Nuestra misión es hacer el acceso a experiencia real y desarrollo de liderazgo más equitativo.',
-    en: 'Yes — SheHub is 100% free for both contributors and mentors. Our mission is to make access to real experience and leadership development more equitable.',
-    ca: "Sí — SheHub és 100% gratuït per a col·laboradores i mentores. La nostra missió és fer l'accés a experiència real i desenvolupament de lideratge més equitatiu.",
+    es: 'Mentoría guiada, trabajo en equipo en un proyecto real con entregas y feedback, y una comunidad tech. El objetivo es que ganes experiencia práctica y material sólido para tu portfolio.',
+    en: 'Guided mentorship, teamwork on a real project with deliverables and feedback, and a tech community. The goal is practical experience and strong portfolio material.',
+    ca: "Mentorització guiada, treball en equip en un projecte real amb lliuraments i feedback, i una comunitat tech. L'objectiu és guanyar experiència pràctica i material sòlid per al teu portafoli.",
   },
   'home.faq.q4': {
     es: '¿Cuánto duran los proyectos?',

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -10,8 +10,10 @@ import { passwordResetModalTranslations } from '@/translations/auth/passwordRese
 import { passwordResetTranslations } from '@/translations/auth/passwordResetTranslations'
 import { registerFormTranslations } from '@/translations/auth/registerFormTranslations'
 import { waitlistTranslations } from '@/translations/auth/waitlistTranslations'
+import { copyEmailTranslations } from '@/translations/layout/copyEmailTranslations'
 import { navigationMenuButtonTranslations } from '@/translations/layout/navbar/navigationMenuButtonTranslations'
 import { navigationMenuTranslations } from '@/translations/layout/navbar/navigationMenuTranslations'
+import { heritageTranslations } from '@/translations/heritage/heritageTranslations'
 import { homeTranslations } from '@/translations/home/homeTranslations'
 import { underConstructionTranslations } from '@/translations/layout/underConstructionTranslations'
 import { testTranslations } from '@/translations/testTranslations'
@@ -20,8 +22,10 @@ import type { TranslationObject } from '@/translations/types'
 export const translations: TranslationObject = {
   ...testTranslations,
   ...homeTranslations,
+  ...heritageTranslations,
   ...navigationMenuTranslations,
   ...navigationMenuButtonTranslations,
+  ...copyEmailTranslations,
   ...underConstructionTranslations,
   ...authFormTranslations,
   ...authTextV1Translations,

--- a/src/translations/layout/copyEmailTranslations.ts
+++ b/src/translations/layout/copyEmailTranslations.ts
@@ -1,0 +1,34 @@
+import type { TranslationObject } from '@/translations/types'
+
+export const copyEmailTranslations: TranslationObject = {
+  'copyEmail.title': {
+    es: 'Correo de contacto',
+    en: 'Contact email',
+    ca: 'Correu de contacte',
+  },
+  'copyEmail.description': {
+    es: 'Copia la dirección y pégala donde quieras escribirnos. No se abrirá tu programa de correo.',
+    en: 'Copy the address and paste it wherever you want to write to us. Your mail app will not open.',
+    ca: 'Copia l’adreça i enganxa-la on vulguis escriure’ns. No s’obrirà el teu client de correu.',
+  },
+  'copyEmail.copy': {
+    es: 'Copiar',
+    en: 'Copy',
+    ca: 'Copiar',
+  },
+  'copyEmail.close': {
+    es: 'Cerrar',
+    en: 'Close',
+    ca: 'Tancar',
+  },
+  'copyEmail.copied': {
+    es: 'Copiado al portapapeles',
+    en: 'Copied to clipboard',
+    ca: 'Copiat al porta-retalls',
+  },
+  'copyEmail.openLabel': {
+    es: 'Ver opciones para copiar el correo info@shehub.es',
+    en: 'See options to copy info@shehub.es',
+    ca: 'Veure opcions per copiar el correu info@shehub.es',
+  },
+}


### PR DESCRIPTION
## Description
Aligned registration and waitlist links to use `/join` instead of `/auth`, introduced a WIP heritage/site journey experience (`/heritage`), and improved contact flow, accessibility focus handling, and form UI styling according to Figma.

## Changes
- Updated CTAs and links from `/auth` to `/join` across pages (home, about, mentors/collaborators/partners, FAQ)
- Added WIP heritage journey pages (`/heritage`, `/heritage/[era]`) with translations and era-based team content
- Implemented email contact flow using `CopyEmailTrigger` with clipboard copy and dialog instead of direct `mailto:`
- Added `user-is-tabbing` logic to improve keyboard vs mouse focus behavior and updated focus styles in `globals.css`
- Enhanced form UI with Figma-aligned tokens and styles for inputs and dropdowns (focus, hover, menu panel, highlighted items)
- Hid/commented navigation link for heritage until feature activation

## Testing
- [X] Code follows project coding standards
- [X] Verified all “join / register / waitlist” links redirect to `/join` instead of `/auth` (except intended cases)
- [X] Tested contact dialog and clipboard copy functionality in footer and contact section
- [X] Checked keyboard (Tab) focus visibility and ensured no intrusive focus ring with mouse interactions
