### PR TITLE
fix(routing): point CTAs and redirects from /auth to /join

### DIFF
--- a/src/app/auth/callback/linkedin/page.tsx
+++ b/src/app/auth/callback/linkedin/page.tsx
@@ -18,7 +18,7 @@ function LinkedInCallbackContent() {
         setStatus('error');
         setMessage(`Error de LinkedIn: ${error}`);
         setTimeout(() => {
-          window.location.href = '/auth';
+          window.location.href = '/join';
         }, 3000);
         return;
       }
@@ -27,7 +27,7 @@ function LinkedInCallbackContent() {
         setStatus('error');
         setMessage('No se recibió código de autorización');
         setTimeout(() => {
-          window.location.href = '/auth';
+          window.location.href = '/join';
         }, 3000);
         return;
       }
@@ -37,7 +37,7 @@ function LinkedInCallbackContent() {
         setStatus('error');
         setMessage('Error de seguridad: state no coincide');
         setTimeout(() => {
-          window.location.href = '/auth';
+          window.location.href = '/join';
         }, 3000);
         return;
       }
@@ -77,7 +77,7 @@ function LinkedInCallbackContent() {
         setStatus('error');
         setMessage(error instanceof Error ? error.message : 'Error al conectar con el servidor');
         setTimeout(() => {
-          window.location.href = '/auth';
+          window.location.href = '/join';
         }, 3000);
       }
     };

--- a/src/app/auth/linkedin/callback/page.tsx
+++ b/src/app/auth/linkedin/callback/page.tsx
@@ -18,7 +18,7 @@ function LinkedInCallbackContent() {
         setStatus('error');
         setMessage(`Error de LinkedIn: ${error}`);
         setTimeout(() => {
-          window.location.href = '/auth';
+          window.location.href = '/join';
         }, 3000);
         return;
       }
@@ -28,7 +28,7 @@ function LinkedInCallbackContent() {
         setStatus('error');
         setMessage('No se recibió código de autorización');
         setTimeout(() => {
-          window.location.href = '/auth';
+          window.location.href = '/join';
         }, 3000);
         return;
       }
@@ -38,7 +38,7 @@ function LinkedInCallbackContent() {
         setStatus('error');
         setMessage('Error de seguridad: state no coincide');
         setTimeout(() => {
-          window.location.href = '/auth';
+          window.location.href = '/join';
         }, 3000);
         return;
       }
@@ -80,7 +80,7 @@ function LinkedInCallbackContent() {
         setStatus('error');
         setMessage(error instanceof Error ? error.message : 'Error al conectar con el servidor');
         setTimeout(() => {
-          window.location.href = '/auth';
+          window.location.href = '/join';
         }, 3000);
       }
     };

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -17,7 +17,7 @@ function ResetPasswordContent() {
 
   const handleClose = () => {
     setIsOpen(false);
-    window.location.href = '/auth';
+    window.location.href = '/join';
   };
 
   if (!token) {
@@ -31,7 +31,7 @@ function ResetPasswordContent() {
             No se encontró un token válido en la URL.
           </p>
           <a
-            href="/auth"
+            href="/join"
             className="inline-block px-6 py-2.5 rounded-lg font-bold text-base transition-all hover:opacity-90"
             style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-white)' }}
           >

--- a/src/hooks/usePasswordReset.ts
+++ b/src/hooks/usePasswordReset.ts
@@ -1,5 +1,5 @@
-import { useLanguage } from '@/providers/LanguageProvider';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useLanguage } from '@/providers/LanguageProvider';
 import { useState } from 'react';
 
 interface UsePasswordResetReturn {
@@ -107,7 +107,7 @@ export const usePasswordReset = (): UsePasswordResetReturn => {
       setResetType('success');
 
       setTimeout(() => {
-        window.location.href = '/auth';
+        window.location.href = '/join';
       }, 2000);
 
     } catch (error) {

--- a/src/sections/collaborators/hero/Hero.tsx
+++ b/src/sections/collaborators/hero/Hero.tsx
@@ -19,7 +19,7 @@ export default function CollaboratorsHero() {
       mainImage={HeroImage.src}
       alt="Collaborators working together"
       buttons={[
-        { text: "Become a collaborator", variant: "primary-primary", href: "/auth" },
+        { text: "Become a collaborator", variant: "primary-primary", href: "/join" },
       ]}
     />
   )

--- a/src/sections/collaborators/whyCollaborator/WhyCollaborator.tsx
+++ b/src/sections/collaborators/whyCollaborator/WhyCollaborator.tsx
@@ -43,7 +43,7 @@ export default function WhyCollaborator() {
       button={{
         text: "Become a collaborator",
         variant: "secondary-primary",
-        href: "/auth",
+        href: "/join",
       }}
       backgroundClassName="bg-purple-100"
       layout="left-aligned"


### PR DESCRIPTION
## Description
Updated user-facing navigation and post-flow redirects to consistently use the `/join` page instead of the legacy `/auth` route, improving UX consistency.

## Changes
- Updated Collaborators hero and “why collaborator” CTAs to point to `/join`
- Changed password reset success redirect and reset-password page link to `/join`
- Modified LinkedIn OAuth callback pages to redirect to `/join` after success or error

## Testing
- [x] Code follows project coding standards
- [x] Verify Collaborators and other pages primary CTAs open `/join`
