### PR TITLE
fix(auth): add missing aria label translations

### DIFF
--- a/src/translations/auth/authFormTranslations.ts
+++ b/src/translations/auth/authFormTranslations.ts
@@ -12,6 +12,21 @@ export const authFormTranslations: TranslationObject = {
     en: 'Sign Up',
     ca: 'Registrar-se',
   },
+  'auth.toggle.ariaLabel': {
+    es: 'Modo de autenticación',
+    en: 'Authentication mode',
+    ca: "Mode d'autenticació",
+  },
+  'auth.form.login.ariaLabel': {
+    es: 'Formulario de inicio de sesión',
+    en: 'Login form',
+    ca: "Formulari d'inici de sessió",
+  },
+  'auth.form.signup.ariaLabel': {
+    es: 'Formulario de registro',
+    en: 'Sign up form',
+    ca: 'Formulari de registre',
+  },
 
   // Common fields
   'auth.field.email': {


### PR DESCRIPTION
## Description
Adds missing authentication aria label translations to prevent missing translation warnings and improve accessibility metadata for auth forms.

## Changes
- Added `auth.toggle.ariaLabel` translation key
- Added `auth.form.login.ariaLabel` translation key
- Added `auth.form.signup.ariaLabel` translation key
- Removed missing translation warnings from the auth form toggle and form aria labels

## Testing
- [x] Code follows project coding standards
- [x] `git diff --check`
- [x] Verify the auth form toggle no longer shows missing translation warnings

## Related Task
https://github.com/SheHub-es/shehub-website/issues/144