### PR TITLE
Fix/cookies

### DIFF
--- a/src/components/layout/CookieBanner.tsx
+++ b/src/components/layout/CookieBanner.tsx
@@ -146,7 +146,7 @@ const CookieBanner = () => {
       >
         <div className="flex min-h-0 flex-1 flex-col gap-6 p-6 pb-0 lg:flex-none">
           <div className="flex shrink-0 items-start justify-between gap-4">
-            <h2 className="font-primary text-size-400 font-heavy leading-line-height-heading-6">
+            <h2 className="font-primary text-size-400 font-heavy leading-line-height-heading-6 text-foreground">
               {t('cookieBanner.preferencesTitle')}
             </h2>
             <button
@@ -196,7 +196,7 @@ const CookieBanner = () => {
           <NextImage src={CookieIcon} alt="" width={24} height={24} className="mt-1 shrink-0" />
 
           <div className="flex flex-col gap-2">
-            <h2 className="font-primary text-size-400 font-heavy leading-line-height-heading-6">
+            <h2 className="font-primary text-size-400 font-heavy leading-line-height-heading-6 text-foreground">
               {t('cookieBanner.title')}
             </h2>
             <p className="font-secondary text-size-300 leading-line-height-body-3 text-foreground">

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -25,7 +25,7 @@ const variants = {
     "hover:bg-[var(--color-button-primary-primary-bg-hover)] hover:!text-[var(--color-button-primary-primary-text-hover)]",
 
   "secondary-primary":
-    "bg-[var(--color-button-secondary-primary-bg-default)] text-[var(--color-button-secondary-primary-text)] " +
+    "bg-[var(--color-button-secondary-primary-bg-default)] !text-[var(--color-button-secondary-primary-text)] " +
     "border border-[var(--color-button-secondary-primary-border)] " +
     "hover:bg-[var(--color-button-secondary-primary-bg-hover)] hover:!text-[var(--color-button-secondary-primary-text-hover)]",
 

--- a/src/components/ui/Timeline.tsx
+++ b/src/components/ui/Timeline.tsx
@@ -217,14 +217,11 @@ export const Timeline: React.FC<TimelineProps> = ({
                                                 className="h-3 w-3 shrink-0 rounded-full bg-accent"
                                                 role="presentation"
                                             />
-                                            {(!isLast || extendLastLine || item.variant === "final") && (
+                                            {(!isLast || extendLastLine) && (
                                                 <div className="w-0.5 bg-(--color-neutral-300) flex-1 min-h-[80px] mt-1.5" />
                                             )}
-                                            {isLast && extendLastLine && item.variant !== "final" && (
-                                                <div className="w-0.5 bg-(--color-neutral-300) h-16 mt-1.5" />
-                                            )}
                                         </div>
-                                        <TimelineRevealOnScroll className="flex-1 pb-6" enabled={revealOnScroll}>
+                                        <TimelineRevealOnScroll className={cn("flex-1", isLast ? "pb-0" : "pb-6")} enabled={revealOnScroll}>
                                             <TimelineItemContent
                                                 id={item.id ? `timeline-item-${item.id}-mobile` : `timeline-item-${index}-mobile`}
                                                 date={item.date}

--- a/src/sections/about/ourTeam/OurTeam.tsx
+++ b/src/sections/about/ourTeam/OurTeam.tsx
@@ -14,9 +14,9 @@ const teamMembers: TeamMember[] = [
   {
     id: '1',
     name: 'Mónica Esteban',
-    role: 'Partnerships & Tools',
+    roleKey: 'about.ourTeam.monica.role',
     photo: MonicaPhoto,
-    description: 'Our founder, heart and soul behind SheHub. Manages company partnerships and sponsorship opportunities that support our mission.',
+    descriptionKey: 'about.ourTeam.monica.description',
     socials: {
       linkedin: 'https://www.linkedin.com/in/monicaestebanponce/',
     },
@@ -24,9 +24,9 @@ const teamMembers: TeamMember[] = [
   {
     id: '2',
     name: 'Anna Sarrià',
-    role: 'Product & Projects',
+    roleKey: 'about.ourTeam.anna.role',
     photo: AnnaPhoto,
-    description: 'Oversees the roadmap of what is built in each cohort. Helps with project scopes, goals, or how to align deliverables with SheHub’s strategy.',
+    descriptionKey: 'about.ourTeam.anna.description',
     socials: {
       linkedin: 'https://www.linkedin.com/in/anna-sarria/',
     },
@@ -34,9 +34,9 @@ const teamMembers: TeamMember[] = [
   {
     id: '3',
     name: 'Norma Díaz-Vergara',
-    role: 'Talent & Projects',
+    roleKey: 'about.ourTeam.norma.role',
     photo: NormaPhoto,
-    description: 'Coordinates mentors, strengthens talent experience and defines development paths to improve learning and collaboration across cohorts.',
+    descriptionKey: 'about.ourTeam.norma.description',
     socials: {
       linkedin: 'https://www.linkedin.com/in/normadiazvergara/',
     },
@@ -44,9 +44,9 @@ const teamMembers: TeamMember[] = [
   {
     id: '4',
     name: 'Jessica Arroyo',
-    role: 'IT & Tech Support',
+    roleKey: 'about.ourTeam.jessica.role',
     photo: JessicaPhoto,
-    description: 'Takes care of development, GitHub, and tech stack. Supports teams with setup, troubleshooting, and keeping  technical foundation solid.',
+    descriptionKey: 'about.ourTeam.jessica.description',
     socials: {
       linkedin: 'https://www.linkedin.com/in/jessica-arroyo-lebron/',
     },
@@ -54,9 +54,9 @@ const teamMembers: TeamMember[] = [
   {
     id: '5',
     name: 'Cristina Ariso',
-    role: 'Governance & Ops',
+    roleKey: 'about.ourTeam.cristina.role',
     photo: CristinaPhoto,
-    description: 'Oversees governance and operations, making sure processes, documentation, and structure stay clear, organised and aligned with our long-term vision.',
+    descriptionKey: 'about.ourTeam.cristina.description',
     socials: {
       linkedin: 'https://www.linkedin.com/in/cristinaariso/',
     },

--- a/src/sections/about/ourTeam/TeamCard.tsx
+++ b/src/sections/about/ourTeam/TeamCard.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 
 import { useId } from 'react';
 import IconCircleArrowRight from '@/components/icons/IconCircleArrowRight';
+import { useTranslation } from '@/hooks/useTranslation';
 
 function LinkedInIcon({ width = 44, height = 44 }: { width?: number; height?: number }) {
   const clipId = useId();
@@ -25,10 +26,10 @@ function LinkedInIcon({ width = 44, height = 44 }: { width?: number; height?: nu
 export type TeamMember = {
   id: string;
   name: string;
-  role: string;
+  roleKey: string;
   photo: StaticImageData;
   socials?: { linkedin?: string };
-  description?: string;
+  descriptionKey?: string;
 };
 
 interface TeamCardProps {
@@ -37,6 +38,9 @@ interface TeamCardProps {
 
 export function TeamCard({ member }: TeamCardProps) {
   const [flipped, setFlipped] = useState(false);
+  const { t } = useTranslation();
+  const role = t(member.roleKey);
+  const description = member.descriptionKey ? t(member.descriptionKey) : undefined;
 
   return (
     <div
@@ -50,7 +54,7 @@ export function TeamCard({ member }: TeamCardProps) {
       }}
       role="button"
       tabIndex={0}
-      aria-label={`${member.name} – ${member.role}. Click to ${flipped ? 'see photo' : 'see details'}`}
+      aria-label={`${member.name} – ${role}. ${flipped ? t('about.ourTeam.card.clickToSeePhoto') : t('about.ourTeam.card.clickToSeeDetails')}`}
     >
       <div className={`team-card-inner ${flipped ? 'team-card-flipped' : ''}`}>
         {/* ── FRONT ── */}
@@ -71,7 +75,7 @@ export function TeamCard({ member }: TeamCardProps) {
           <div className="team-card-info">
             <div className="team-card-text">
               <h3 className="team-card-name">{member.name}</h3>
-              <p className="team-card-role">{member.role}</p>
+              <p className="team-card-role">{role}</p>
             </div>
             <span className="team-card-arrow" aria-hidden="true">
               <IconCircleArrowRight width={52} height={52} />
@@ -83,10 +87,10 @@ export function TeamCard({ member }: TeamCardProps) {
         <div className="team-card-face team-card-back">
           <div className="team-card-back-content">
             <h3 className="team-card-name">{member.name}</h3>
-            <p className="team-card-role">{member.role}</p>
+            <p className="team-card-role">{role}</p>
 
-            {member.description && (
-              <p className="team-card-description">{member.description}</p>
+            {description && (
+              <p className="team-card-description">{description}</p>
             )}
 
             {member.socials?.linkedin && (
@@ -96,7 +100,7 @@ export function TeamCard({ member }: TeamCardProps) {
                 rel="noreferrer"
                 className="team-card-linkedin-icon"
                 onClick={(e) => e.stopPropagation()}
-                aria-label={`${member.name} LinkedIn profile`}
+                aria-label={`${member.name} ${t('about.ourTeam.card.linkedinProfile')}`}
               >
                 <LinkedInIcon width={44} height={44} />
               </a>
@@ -109,7 +113,7 @@ export function TeamCard({ member }: TeamCardProps) {
               e.stopPropagation();
               setFlipped(false);
             }}
-            aria-label="Go back to front"
+            aria-label={t('about.ourTeam.card.goBack')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="52" height="52" fill="none" viewBox="0 0 52 52">
               <path stroke="#0E0E0E" strokeLinecap="round" strokeLinejoin="round" strokeWidth="4" d="M26 17.333 17.333 26m0 0L26 34.667M17.333 26h17.334m13 0c0 11.966-9.7 21.667-21.667 21.667-11.966 0-21.667-9.7-21.667-21.667 0-11.966 9.7-21.667 21.667-21.667 11.966 0 21.667 9.7 21.667 21.667Z"/>

--- a/src/translations/about/aboutTranslations.ts
+++ b/src/translations/about/aboutTranslations.ts
@@ -200,7 +200,78 @@ export const aboutTranslations: TranslationObject = {
     ca: 'Funcionem amb confiança i propietat compartida, i cap persona pren decisions sola. Això ens manté honestes, àgils i centrades en allò que realment importa a la comunitat.',
   },
 
-  'about.cta.title': { 
+  'about.ourTeam.monica.role': {
+    es: 'Alianzas y Herramientas',
+    en: 'Partnerships & Tools',
+    ca: 'Aliances i Eines',
+  },
+  'about.ourTeam.monica.description': {
+    es: 'Nuestra fundadora, corazón y alma detrás de SheHub. Gestiona las alianzas de la empresa y las oportunidades de patrocinio que apoyan nuestra misión.',
+    en: 'Our founder, heart and soul behind SheHub. Manages company partnerships and sponsorship opportunities that support our mission.',
+    ca: 'La nostra fundadora, cor i ànima darrere de SheHub. Gestiona les aliances de l\'empresa i les oportunitats de patrocini que donen suport a la nostra missió.',
+  },
+  'about.ourTeam.anna.role': {
+    es: 'Producto y Proyectos',
+    en: 'Product & Projects',
+    ca: 'Producte i Projectes',
+  },
+  'about.ourTeam.anna.description': {
+    es: 'Supervisa la hoja de ruta de lo que se construye en cada cohorte. Ayuda con el alcance de los proyectos, los objetivos y cómo alinear los entregables con la estrategia de SheHub.',
+    en: 'Oversees the roadmap of what is built in each cohort. Helps with project scopes, goals, or how to align deliverables with SheHub’s strategy.',
+    ca: 'Supervisa el full de ruta del que es construeix a cada cohort. Ajuda amb l\'abast dels projectes, els objectius i com alinear els lliurables amb l\'estratègia de SheHub.',
+  },
+  'about.ourTeam.norma.role': {
+    es: 'Talento y Proyectos',
+    en: 'Talent & Projects',
+    ca: 'Talent i Projectes',
+  },
+  'about.ourTeam.norma.description': {
+    es: 'Coordina a las mentoras, fortalece la experiencia del talento y define itinerarios de desarrollo para mejorar el aprendizaje y la colaboración en las cohortes.',
+    en: 'Coordinates mentors, strengthens talent experience and defines development paths to improve learning and collaboration across cohorts.',
+    ca: 'Coordina les mentores, enforteix l\'experiència del talent i defineix itineraris de desenvolupament per millorar l\'aprenentatge i la col·laboració a les cohorts.',
+  },
+  'about.ourTeam.jessica.role': {
+    es: 'TI y Soporte Técnico',
+    en: 'IT & Tech Support',
+    ca: 'TI i Suport Tècnic',
+  },
+  'about.ourTeam.jessica.description': {
+    es: 'Se encarga del desarrollo, GitHub y la pila tecnológica. Apoya a los equipos con la configuración, la resolución de problemas y mantiene sólida la base técnica.',
+    en: 'Takes care of development, GitHub, and tech stack. Supports teams with setup, troubleshooting, and keeping technical foundation solid.',
+    ca: 'S\'encarrega del desenvolupament, GitHub i la pila tecnològica. Dona suport als equips amb la configuració, la resolució de problemes i manté sòlida la base tècnica.',
+  },
+  'about.ourTeam.cristina.role': {
+    es: 'Gobernanza y Operaciones',
+    en: 'Governance & Ops',
+    ca: 'Governança i Operacions',
+  },
+  'about.ourTeam.cristina.description': {
+    es: 'Supervisa la gobernanza y las operaciones, asegurando que los procesos, la documentación y la estructura se mantengan claros, organizados y alineados con nuestra visión a largo plazo.',
+    en: 'Oversees governance and operations, making sure processes, documentation, and structure stay clear, organised and aligned with our long-term vision.',
+    ca: 'Supervisa la governança i les operacions, assegurant que els processos, la documentació i l\'estructura es mantinguin clars, organitzats i alineats amb la nostra visió a llarg termini.',
+  },
+  'about.ourTeam.card.clickToSeeDetails': {
+    es: 'Haz clic para ver los detalles',
+    en: 'Click to see details',
+    ca: 'Fes clic per veure els detalls',
+  },
+  'about.ourTeam.card.clickToSeePhoto': {
+    es: 'Haz clic para ver la foto',
+    en: 'Click to see photo',
+    ca: 'Fes clic per veure la foto',
+  },
+  'about.ourTeam.card.linkedinProfile': {
+    es: 'Perfil de LinkedIn',
+    en: 'LinkedIn profile',
+    ca: 'Perfil de LinkedIn',
+  },
+  'about.ourTeam.card.goBack': {
+    es: 'Volver al frente',
+    en: 'Go back to front',
+    ca: 'Tornar al davant',
+  },
+
+  'about.cta.title': {
     es: '¿Quieres ser parte de la comunidad?',
     en: 'Want to be part of the community?',
     ca: 'Vols formar part de la comunitat?',


### PR DESCRIPTION
## Summary
Fixes an issue where the CookieBanner's h2 headings (banner title and preferences panel title) and the "Manage preferences" button label could render without their intended black text color on some pages, making them unreadable.
Root cause: both elements relied on inherited color / a non-!important text-[var(...)] utility with no explicit precedence, so on some routes the color was silently overridden by the ambient CSS cascade.
h2 elements in CookieBanner.tsx now explicitly set text-foreground.
The secondary-primary Button variant's base (non-hover) text color now uses !text-[var(--color-button-secondary-primary-text)], matching the existing !text-[...] pattern already used for primary-primary and for this variant's own hover state.
I have also included the translations in OurTeam cards in this PR.

## Test plan
[] Load the cookie banner on a few different routes and confirm the title ("Your cookies, your choice")and "Manage preferences" button text render in black (clear cache/delete cookies if needs be)
[] Open the "Manage preferences" panel and confirm the panel heading is also visible
[] Check the Our Team card texts change language when toggling