### PR TITLE
refactor(hero): images, alt texts & accessibility

### DIFF
--- a/src/sections/about/hero/components/ImageSection.tsx
+++ b/src/sections/about/hero/components/ImageSection.tsx
@@ -20,13 +20,13 @@ const ImageSection = () => {
   return (
     <div
       ref={containerRef}
-      className="relative z-1 mx-auto mt-8 h-[420px] w-full max-w-[420px] md:mt-16 lg:h-[480px] lg:max-w-[480px]"
+      className="relative z-1 mx-auto mb-8 h-[420px] w-full max-w-[420px] md:mt-16 lg:mb-0 lg:h-[480px] lg:max-w-[480px]"
     >
       <NextImage
         src={PurpleRectangleImage}
         alt=""
         className={cn(
-          "absolute top-1/2 left-1/2 h-auto w-[280px] -translate-x-1/2 -translate-y-1/2 lg:w-[327px]",
+          "absolute top-1/2 left-1/2 h-auto w-[66.67%] -translate-x-1/2 -translate-y-1/2",
           fade
         )}
       />
@@ -34,7 +34,7 @@ const ImageSection = () => {
         src={CollabWomenImage}
         alt={t('about.hero.collabWomenAlt')}
         className={cn(
-          "absolute top-2 left-2 h-auto w-[170px] rounded-3xl rounded-br-none object-cover lg:top-0 lg:left-0 lg:w-55",
+          "absolute top-[1.9%] left-[1.9%] h-auto w-[40.48%] rounded-3xl rounded-br-none object-cover",
           fade
         )}
       />
@@ -42,7 +42,7 @@ const ImageSection = () => {
         src={RobotImage}
         alt={t('about.hero.robotAlt')}
         className={cn(
-          "absolute top-[190px] left-10 h-auto w-26.25 rounded-3xl rounded-tr-none object-cover lg:top-55 lg:left-12.5 lg:w-34.5",
+          "absolute top-[45.24%] left-[9.52%] h-auto w-[25%] rounded-3xl rounded-tr-none object-cover",
           fade
         )}
       />
@@ -50,7 +50,7 @@ const ImageSection = () => {
         src={SheHubPinkImage}
         alt=""
         className={cn(
-          "absolute bottom-4 left-10 h-auto w-[110px] lg:bottom-6 lg:left-6 lg:w-[140px]",
+          "absolute bottom-[3.81%] left-[9.52%] h-auto w-[26.19%]",
           fade
         )}
       />
@@ -58,7 +58,7 @@ const ImageSection = () => {
         src={ArrowIcon}
         alt=""
         className={cn(
-          "absolute top-8.5 left-55.5 h-auto w-17.5 lg:top-8 lg:left-63 lg:w-21.5",
+          "absolute top-[8.1%] left-[52.86%] h-auto w-[16.67%]",
           fade
         )}
       />
@@ -66,7 +66,7 @@ const ImageSection = () => {
         src={LaptopImage}
         alt={t('about.hero.laptopAlt')}
         className={cn(
-          "absolute right-0 bottom-0 h-auto w-[190px] rounded-[35px] rounded-tl-none object-cover shadow-lg lg:w-60 lg:rounded-[44px] lg:rounded-tl-none",
+          "absolute right-0 bottom-0 h-auto w-[45.24%] rounded-[35px] rounded-tl-none object-cover shadow-lg lg:rounded-[44px] lg:rounded-tl-none",
           fade
         )}
       />
@@ -74,7 +74,7 @@ const ImageSection = () => {
         src={AsteriskIcon}
         alt=""
         className={cn(
-          "absolute top-[190px] left-47.5 h-auto w-11.25 lg:top-55 lg:left-56.25 lg:w-14",
+          "absolute top-[45.24%] left-[45.24%] h-auto w-[10.71%]",
           fade
         )}
       />

--- a/src/sections/about/hero/components/ImageSection.tsx
+++ b/src/sections/about/hero/components/ImageSection.tsx
@@ -15,8 +15,7 @@ const ImageSection = () => {
   const [containerRef, isVisible] = useIntersectionObserver();
   const { t } = useTranslation();
 
-  const fade = (stagger: "a" | "b" | "c" | "d") =>
-    cn("fade-on-scroll", `stagger-${stagger}`, isVisible && "visible");
+  const fade = cn("fade-on-scroll", isVisible && "visible");
 
   return (
     <div
@@ -28,7 +27,7 @@ const ImageSection = () => {
         alt=""
         className={cn(
           "absolute top-1/2 left-1/2 h-auto w-[280px] -translate-x-1/2 -translate-y-1/2 lg:w-[327px]",
-          fade("a")
+          fade
         )}
       />
       <NextImage
@@ -36,7 +35,7 @@ const ImageSection = () => {
         alt={t('about.hero.collabWomenAlt')}
         className={cn(
           "absolute top-2 left-2 h-auto w-[170px] rounded-3xl rounded-br-none object-cover lg:top-0 lg:left-0 lg:w-55",
-          fade("b")
+          fade
         )}
       />
       <NextImage
@@ -44,7 +43,7 @@ const ImageSection = () => {
         alt={t('about.hero.robotAlt')}
         className={cn(
           "absolute top-[190px] left-10 h-auto w-26.25 rounded-3xl rounded-tr-none object-cover lg:top-55 lg:left-12.5 lg:w-34.5",
-          fade("b")
+          fade
         )}
       />
       <NextImage
@@ -52,7 +51,7 @@ const ImageSection = () => {
         alt=""
         className={cn(
           "absolute bottom-4 left-10 h-auto w-[110px] lg:bottom-6 lg:left-6 lg:w-[140px]",
-          fade("b")
+          fade
         )}
       />
       <NextImage
@@ -60,7 +59,7 @@ const ImageSection = () => {
         alt=""
         className={cn(
           "absolute top-8.5 left-55.5 h-auto w-17.5 lg:top-8 lg:left-63 lg:w-21.5",
-          fade("c")
+          fade
         )}
       />
       <NextImage
@@ -68,7 +67,7 @@ const ImageSection = () => {
         alt={t('about.hero.laptopAlt')}
         className={cn(
           "absolute right-0 bottom-0 h-auto w-[190px] rounded-[35px] rounded-tl-none object-cover shadow-lg lg:w-60 lg:rounded-[44px] lg:rounded-tl-none",
-          fade("d")
+          fade
         )}
       />
       <NextImage
@@ -76,7 +75,7 @@ const ImageSection = () => {
         alt=""
         className={cn(
           "absolute top-[190px] left-47.5 h-auto w-11.25 lg:top-55 lg:left-56.25 lg:w-14",
-          fade("d")
+          fade
         )}
       />
     </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -57,21 +57,6 @@
     animation-delay: 600ms;
   }
 
-  .stagger-a {
-    transition-delay: 0ms;
-  }
-
-  .stagger-b {
-    transition-delay: 200ms;
-  }
-
-  .stagger-c {
-    transition-delay: 400ms;
-  }
-
-  .stagger-d {
-    transition-delay: 600ms;
-  }
 }
 
 @theme {


### PR DESCRIPTION
## Summary
Adds the ImageSection component for the About page hero — layered photos, decorative SVGs (arrow, asterisk), and fade. Page previously featured one static "collage"-style image with a single alt.
Improves accessibility on ImageSection and HeroLayout: descriptive alt text for meaningful images, empty alt="" on decorative graphics, and related translation keys added across es/en/ca.
Fixes a couple of typos in the existing hero copy.

## Test plan
[] Visually verify About hero renders correctly across breakpoints (mobile/tablet/desktop)
[] Verify images have similar style to other pages
[] Verify alt text reads correctly with a screen reader for photos, and decorative icons are skipped
[] Verify es/en/ca translations render correctly