### PR TITLE
fix(switch): prevent parent state update during render

### DIFF
--- a/src/components/ui/Switch.tsx
+++ b/src/components/ui/Switch.tsx
@@ -35,12 +35,11 @@ const Switch: React.FC<SwitchProps> = ({
   id,
 }) => {
   const { t } = useTranslation();
-  const [checked, setChecked] = useState(checkedProp);
   const generatedId = useId();
   const switchId = id || generatedId;
   const helperId = helperText ? `${switchId}-helper` : undefined;
 
-  const isOn = disabled ? true : checked;
+  const isOn = disabled ? true : checkedProp;
   const [displayOn, setDisplayOn] = useState(isOn);
 
   useEffect(() => {
@@ -53,16 +52,11 @@ const Switch: React.FC<SwitchProps> = ({
 
   const toggle = () => {
     if (disabled) return;
-    setChecked((prev) => {
-      const next = !prev;
-      onChange?.(next);
-      return next;
-    });
+    onChange?.(!checkedProp);
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (disabled) return;
-    setChecked(e.target.checked);
     onChange?.(e.target.checked);
   };
 


### PR DESCRIPTION
## Description
Fixes the cookie banner `Switch` component to prevent `CookieBanner` state updates during rendering and ensures predictable controlled-component behavior.

## Changes
- Remove duplicated internal state from `Switch`
- Use the `checked` prop as the single source of truth
- Trigger `onChange` only in response to user interaction
- Prevent the React warning `Cannot update a component while rendering a different component`

## Testing
- [x] Code follows project coding standards
- [x] TypeScript validation passes
- [x] Production build completes successfully
- [x] Verify cookie preferences can be toggled correctly